### PR TITLE
More about surprise notebook

### DIFF
--- a/notebooks/02_modeling/surprise_svd_deep_dive.ipynb
+++ b/notebooks/02_modeling/surprise_svd_deep_dive.ipynb
@@ -6,7 +6,8 @@
    "source": [
     "# Surprise Singular Value Decomposition (SVD)\n",
     "\n",
-    "TODO: INTRO HERE..."
+    "\n",
+    "This notebook serves both as an introduction to the [Surprise](http://surpriselib.com/) library, and also introduces the 'SVD' algorithm very similar to ALS presented in the ALS deep dive notebook. This algorithm was heavily used during the Netflix Prize competition by the winning BellKor team."
    ]
   },
   {
@@ -39,33 +40,67 @@
     "from reco_utils.dataset.url_utils import maybe_download\n",
     "from reco_utils.dataset.python_splitters import python_random_split\n",
     "from reco_utils.evaluation.python_evaluation import rmse, mae, rsquared, exp_var\n",
+    "from reco_utils.evaluation.python_evaluation import map_at_k, ndcg_at_k, precision_at_k, recall_at_k\n",
     "\n",
     "print(\"System version: {}\".format(sys.version))\n",
     "print(\"Surprise version: {}\".format(surprise.__version__))"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1 Matrix factorization algorithm\n",
+    "\n",
+    "The SVD model algorithm is very similar to the ALS algorithm presented in the ALS deep dive notebook. The two differences between the two approaches are:\n",
+    "\n",
+    "- SVD additionally models the user and item biases (also called baselines in the litterature) from users and items.\n",
+    "- The optimization technique in ALS is Alternating Least Squares (hence the name), while SVD uses stochastic gradient descent.\n",
+    "\n",
+    "### 1.1 The SVD model\n",
+    "\n",
+    "In ALS, the ratings are modeled as follows:\n",
+    "\n",
+    "$$\\hat r_{u,i} = q_{i}^{T}p_{u}$$\n",
+    "\n",
+    "SVD introduces two new scalar variables: the user biases $b_u$ and the item biases $b_i$. The user biases are supposed to capture the tendency of some users to rate items higher (or lower) than the average. The same goes for items: some items are usually rated higher than some others. The model is SVD is then as follows:\n",
+    "\n",
+    "$$\\hat r_{u,i} = \\mu + b_u + b_i + q_{i}^{T}p_{u}$$\n",
+    "\n",
+    "Where $\\mu$ is the global average of all the ratings in the dataset. The regularised optimization problem naturally becomes:\n",
+    "\n",
+    "$$ \\sum(r_{u,i} - (\\mu + b_u + b_i + q_{i}^{T}p_{u}))^2 +     \\lambda(b_i^2 + b_u^2 + ||q_i||^2 + ||p_u||^2)$$\n",
+    "\n",
+    "where $\\lambda$ is a the regularization parameter.\n",
+    "\n",
+    "\n",
+    "### 1.2 Stochastic Gradient Descent\n",
+    "\n",
+    "Stochastic Gradient Descent (SGD) is a very common algorithm for optimization where the parameters (here the biases and the factor vectors) are iteratively incremented with the negative gradients w.r.t the optimization function. The algorithm essentially performs the following steps for a given number of iteration:\n",
+    "\n",
+    "\n",
+    "$$b_u \\leftarrow b_u + \\gamma (e_{ui} - \\lambda b_u)$$\n",
+    "$$b_i \\leftarrow b_i + \\gamma (e_{ui} - \\lambda b_i)$$  \n",
+    "$$p_u \\leftarrow p_u + \\gamma (e_{ui} \\cdot q_i - \\lambda p_u)$$\n",
+    "$$q_i \\leftarrow q_i + \\gamma (e_{ui} \\cdot p_u - \\lambda q_i)$$\n",
+    "\n",
+    "where $\\gamma$ is the learning rate and $e_{ui} =  r_{ui} - \\hat r_{u,i} = r_{u,i} - (\\mu + b_u + b_i + q_{i}^{T}p_{u})$ is the error made by the model for the pair $(u, i)$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1 Load Data\n",
+    "\n",
+    "We will use the movielens dataset, which is composed of integer ratings from 1 to 5. \n",
+    "\n",
+    "Surprise supports dataframes as long as they have three colums reprensenting the user ids, item ids, and the ratings (in this order)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Parameters\n",
-    "# Add here if we need parameters\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "filepath = maybe_download(\"http://files.grouplens.org/datasets/movielens/ml-100k/u.data\", \"ml-100k.data\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -138,20 +173,32 @@
        "4     166      346       1"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "filepath = maybe_download(\"http://files.grouplens.org/datasets/movielens/ml-100k/u.data\", \"ml-100k.data\")\n",
     "data = pd.read_csv(filepath, sep=\"\\t\", names=[\"UserId\", \"MovieId\", \"Rating\", \"Timestamp\"])\n",
     "data = data[[\"UserId\", \"MovieId\", \"Rating\"]]\n",
     "data.head()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2 Train the SVD Model\n",
+    "\n",
+    "Note that Surprise has a lot of built-in support for [cross-validation](https://surprise.readthedocs.io/en/stable/getting_started.html#use-cross-validation-iterators) or also [grid search](https://surprise.readthedocs.io/en/stable/getting_started.html#tune-algorithm-parameters-with-gridsearchcv) inspired scikit-learn, but we will here use the provided tools instead.\n",
+    "\n",
+    "We start by splitting our data into trainset and testset with the `python_random_split` function."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,65 +206,251 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Surprise needs to build an internal model of the data. We here use the `load_from_df` method to build a `Dataset` object, and then indicate that we want to train on all the samples of this dataset by using the `build_full_trainset` method."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 30,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
-   "source": [
-    "train = surprise.Dataset.load_from_df(data, reader=surprise.Reader('ml-100k')).build_full_trainset()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "svd = surprise.SVD().fit(train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "predictions = [svd.predict(row.UserId, row.MovieId, row.Rating) for (_, row) in test.iterrows()]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "predictions_df = pd.DataFrame(predictions)\n",
-    "predictions_df = predictions_df.rename(index=str, columns={'uid': 'User', 'iid': 'itemId', 'est': 'rating'})\n",
-    "predictions_df = predictions_df.drop(['details', 'r_ui'], axis='columns')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.15199328893008127"
+       "<surprise.trainset.Trainset at 0x7fa5edb345f8>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from reco_utils.evaluation.python_evaluation import mean_squared_error\n",
-    "mean_squared_error(test, predictions_df)"
+    "train = surprise.Dataset.load_from_df(data, reader=surprise.Reader('ml-100k')).build_full_trainset()\n",
+    "train"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [SVD](https://surprise.readthedocs.io/en/stable/matrix_factorization.html#surprise.prediction_algorithms.matrix_factorization.SVD) has a lot of parameters but we will here use the defaults (only setting the RNG for reproducibility). To train the model, we simply need to call the `fit()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.matrix_factorization.SVD at 0x7fa5ad5638d0>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "svd = surprise.SVD(random_state=0)\n",
+    "svd.fit(train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that our model is fitted, we can call `predict` to get some predictions. `predict` returns an internal object `Prediction` which can be easily converted back to a dataframe:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>userID</th>\n",
+       "      <th>itemID</th>\n",
+       "      <th>prediction</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>600</td>\n",
+       "      <td>651</td>\n",
+       "      <td>4.226748</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>607</td>\n",
+       "      <td>494</td>\n",
+       "      <td>4.032300</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>875</td>\n",
+       "      <td>1103</td>\n",
+       "      <td>4.475408</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>648</td>\n",
+       "      <td>238</td>\n",
+       "      <td>2.613612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>113</td>\n",
+       "      <td>273</td>\n",
+       "      <td>3.947193</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   userID  itemID  prediction\n",
+       "0     600     651    4.226748\n",
+       "1     607     494    4.032300\n",
+       "2     875    1103    4.475408\n",
+       "3     648     238    2.613612\n",
+       "4     113     273    3.947193"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = [svd.predict(row.UserId, row.MovieId, row.Rating)\n",
+    "               for (_, row) in test.iterrows()]\n",
+    "predictions = pd.DataFrame(predictions)\n",
+    "predictions = predictions.rename(index=str, columns={'uid': 'userID', 'iid': 'itemID',\n",
+    "                                                     'est': 'prediction'})\n",
+    "predictions = predictions.drop(['details', 'r_ui'], axis='columns')\n",
+    "predictions.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Evaluate how well SAR performs \n",
+    "\n",
+    "The SVD algorithm was specifically designed to predict ratings as close as possible to their actual values. In particular, it is designed to have a very low RMSE (Root Mean Squared Error), computed as:\n",
+    "\n",
+    "$$\\sqrt{\\frac{1}{N} (\\hat{r_{ui}} - r_{ui})^2}$$\n",
+    "\n",
+    "As we can see, the RMSE and MAE (Mean Absolute Error) are pretty low (i.e. good), indicating that on average predicted ratings are about 0.5 away from their actual values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.6811193783386692, 0.5397618974081506)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = test.rename(index=str, columns={'UserId': 'userID', 'MovieId': 'itemID', 'Rating': 'rating'})\n",
+    "rmse(test, predictions), mae(test, predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# map_at_k and so on require different column names it seems\n",
+    "\n",
+    "\n",
+    "# predictions_df = predictions_df.rename(index=str, columns={'uid': 'UserId', 'iid': 'MovieId', 'est': 'prediction'})\n",
+    "#predictions_df = predictions_df.drop(['details', 'r_ui'], axis='columns')\n",
+    "\n",
+    "#k = 10\n",
+    "#eval_map = map_at_k(test, predictions_df, col_user=\"UserId\", col_item=\"MovieId\", \n",
+    "#                    col_rating=\"Rating\", col_prediction=\"prediction\", \n",
+    "#                    relevancy_method=\"top_k\", k=k)\n",
+    "#eval_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -225,6 +458,13 @@
    "metadata": {
     "scrolled": true
    },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   },


### PR DESCRIPTION
I cleaned the code and added comments. The notebook is a mix between an introduction to SVD (some overlap with ALS) and an introduction to surprise.

It seems that the `rmse` and `mae` functions accept different dataframe column names from e.g. `map_at_k`.

Let me know if this is going in the right direction.

I haven't written any tests yet, I'll try to do that soon.

Also, not related, but the optimization problem in `als_deep_dive.ipynb` should be 

``$$\min\sum(r_{u,i} - q_{i}^{T}p_{u})^2 + \lambda(||q_{i}||^2 + ||p_{u}||^2)$$`` (without the `\hat` on ` r_{u,i}`).