### PR TITLE
Benchmark static

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Several utilities are provided in [reco_utils](reco_utils) which will help accel
 ## Benchmarks
 
 Here we benchmark all the algorithms available in this repository.
+
 **NOTES**:
 * Time for training and testing is measured in second.
 * Ranking metrics (i.e., precision, recall, map, and ndcg) are evaluated with `k` equal to 10.
+* The machine we used is an [Azure DSVM](https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/) Standard NC6s_v2 with 6 vcpus, 112 GB memory and 1 K80 GPU.
 
 <table>
  <tr>


### PR DESCRIPTION
added static benchmark with movielens, we found memory problems in the spark algos with movielens > 10M

For SAR + to work, see https://github.com/Microsoft/Recommenders/issues/210, we have to add this config:
```
spark = (
    SparkSession.builder.appName("sample")
    .master("local[*]")
    #.config("memory", "24G")
    .config("spark.driver.memory", "64g")
    #.config("spark.executor.memory", "24g")
    .config("spark.sql.shuffle.partitions", "6")
    .config("spark.sql.crossJoin.enabled", True)
    .config("spark.eventLog.enabled", True)
    #.config("spark.ui.enabled", False)
    .config("spark.memory.fraction", "0.9")
    .getOrCreate()
)
```
For pyspark SAR we found that the memory error comes when doing the metrics, see https://github.com/Microsoft/Recommenders/issues/211
