### PR TITLE
ALS notebook smoke and integration tests

### DIFF
--- a/tests/integration/test_notebooks_pyspark.py
+++ b/tests/integration/test_notebooks_pyspark.py
@@ -15,9 +15,9 @@ TOL = 0.5
 @pytest.mark.parametrize(
     "size, result_list",
     [
-        ("1m", [0.02, 0.15, 0.14, 0.07]),
-        ("10m", [0.03, 0.15, 0.14, 0.09]),
-        ("20m", [0.03, 0.15, 0.14, 0.08]),
+        ("1m", [0.02, 0.15, 0.14, 0.07, 0.95, 0.73, 0.28, 0.28]),
+        ("10m", [0.03, 0.15, 0.14, 0.09, 0.85, 0.65, 0.36, 0.36]),
+        ("20m", [0.03, 0.15, 0.14, 0.08, 0.84, 0.63, 0.37, 0.37]),
     ],
 )
 def test_als_pyspark_integration(notebooks, size, result_list):
@@ -38,4 +38,13 @@ def test_als_pyspark_integration(notebooks, size, result_list):
     assert result_precision == pytest.approx(result_list[2], TOL)
     result_recall = df.loc[df["name"] == "recall", "value"].values[0]
     assert result_recall == pytest.approx(result_list[3], TOL)
+
+    result_rmse = df.loc[df["name"] == "rmse", "value"].values[0]
+    assert result_rmse == pytest.approx(result_list[4], TOL)
+    result_mae = df.loc[df["name"] == "mae", "value"].values[0]
+    assert result_mae == pytest.approx(result_list[5], TOL)
+    result_exp_var = df.loc[df["name"] == "exp_var", "value"].values[0]
+    assert result_exp_var == pytest.approx(result_list[6], TOL)
+    result_rsquared = df.loc[df["name"] == "rsquared", "value"].values[0]
+    assert result_rsquared == pytest.approx(result_list[7], TOL)
 

--- a/tests/smoke/test_notebooks_pyspark.py
+++ b/tests/smoke/test_notebooks_pyspark.py
@@ -31,3 +31,12 @@ def test_als_pyspark_smoke(notebooks):
     result_recall = df.loc[df["name"] == "recall", "value"].values[0]
     assert result_recall == pytest.approx(0.07, TOL)
 
+    result_rmse = df.loc[df["name"] == "rmse", "value"].values[0]
+    assert result_rmse == pytest.approx(1.12, TOL)
+    result_mae = df.loc[df["name"] == "mae", "value"].values[0]
+    assert result_mae == pytest.approx(0.87, TOL)
+    result_exp_var = df.loc[df["name"] == "exp_var", "value"].values[0]
+    assert result_exp_var == pytest.approx(0.01, TOL)
+    result_rsquared = df.loc[df["name"] == "rsquared", "value"].values[0]
+    assert result_rsquared == pytest.approx(0.00, TOL)
+


### PR DESCRIPTION
Add rating metrics evaluation to smoke and integration test

### Description
Add mae, exp_var, and rsquared smoke and integration tests to the unit-test functions

### Motivation and Context
We added those metrics in ALS quickstart notebook. 

### Releated Issues

### Checklist:
- [x ] My code follows the code style of this project.
- [x ] I have added tests.
- [ ] I have updated the documentation accordingly.

Thank you for contributing to this repo. Please see our [contribution guidelines](../CONTRIBUTING).


