### PR TITLE
[IGNORE THIS] EVALUATION: force evlauation after relevancy function

### DIFF
--- a/reco_utils/evaluation/spark_evaluation.py
+++ b/reco_utils/evaluation/spark_evaluation.py
@@ -360,6 +360,10 @@ def get_top_k_items(
         .dropDuplicates([col_user, "prediction"])
     )
 
+    # Force evaluation but this leads to overhead.
+    # If it does fix any OOM issues owing to lazy evaluation, keep it. Otherwise, remove it.
+    items_for_user.count()
+
     return items_for_user
 
 
@@ -401,6 +405,10 @@ def get_relevant_items_by_threshold(
         .dropDuplicates()
     )
 
+    # Force evaluation but this leads to overhead.
+    # If it does fix any OOM issues owing to lazy evaluation, keep it. Otherwise, remove it.
+    items_for_user.count()
+
     return items_for_user
 
 
@@ -440,5 +448,9 @@ def get_relevant_items_by_timestamp(
         .select(col_user, "prediction")
         .dropDuplicates([col_user, "prediction"])
     )
+
+    # Force evaluation but this leads to overhead.
+    # If it does fix any OOM issues owing to lazy evaluation, keep it. Otherwise, remove it.
+    items_for_user.count()
 
     return items_for_user


### PR DESCRIPTION
Force evaluation after "relevancy function" is applied

### Description
Force evaluation at the end of relevancy function. 

### Motivation and Context
Lazy evaluation may cause memory issues - forcing evaluation may help resolve the issue. 

### Related Issues
#211 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests.
- [x] I have updated the documentation accordingly.

Thank you for contributing to this repo. Please see our [contribution guidelines](../CONTRIBUTING).


