### PR TITLE
Test whether a PR from a maintainer is executed without label

### DIFF
--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   get-test-groups:
     runs-on: ubuntu-latest
-    # For security: Execute the tests when the PR is from an internal contributor or if it is a fork, when the PR has the label 'safe to test'
+    # For security: Execute the tests when the PR is from a maintainer or if it comes from a fork, when the PR has been labeled 'safe to test' by a maintainer.
     if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == 'false') || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
     steps:
       - name: Check out repository code


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
`    if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == 'false') || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))
`

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/recommenders-team/recommenders/issues/1853

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
