### PR TITLE
Add missing kernelspec language

### DIFF
--- a/examples/00_quick_start/lstur_MIND.ipynb
+++ b/examples/00_quick_start/lstur_MIND.ipynb
@@ -542,6 +542,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/00_quick_start/naml_MIND.ipynb
+++ b/examples/00_quick_start/naml_MIND.ipynb
@@ -539,6 +539,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/00_quick_start/npa_MIND.ipynb
+++ b/examples/00_quick_start/npa_MIND.ipynb
@@ -517,6 +517,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/00_quick_start/nrms_MIND.ipynb
+++ b/examples/00_quick_start/nrms_MIND.ipynb
@@ -536,6 +536,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/00_quick_start/sar_movieratings_with_azureml_designer.ipynb
+++ b/examples/00_quick_start/sar_movieratings_with_azureml_designer.ipynb
@@ -286,6 +286,7 @@
     "metadata": {
         "kernelspec": {
             "name": "python3",
+            "language": "python",
             "display_name": "Python 3.6.8 64-bit ('test': conda)",
             "metadata": {
                 "interpreter": {

--- a/examples/00_quick_start/sequential_recsys_amazondataset.ipynb
+++ b/examples/00_quick_start/sequential_recsys_amazondataset.ipynb
@@ -581,6 +581,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/02_model_collaborative_filtering/lightgcn_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/lightgcn_deep_dive.ipynb
@@ -805,6 +805,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {

--- a/examples/02_model_content_based_filtering/dkn_deep_dive.ipynb
+++ b/examples/02_model_content_based_filtering/dkn_deep_dive.ipynb
@@ -541,6 +541,7 @@
         },
         "kernelspec": {
             "display_name": "Python 3.7.11 64-bit ('tf2': conda)",
+            "language": "python",
             "name": "python3"
         },
         "language_info": {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR corrects the error from the tests for the PR #2035 (https://github.com/recommenders-team/recommenders/actions/runs/6749833187/job/18351722346?pr=2035#step:3:2775)

```
=================================== FAILURES ===================================
________________________________ test_npa_smoke ________________________________

notebooks = ***'als_deep_dive': '/mnt/azureml/cr/j/0d490b7a2cbb414d9d2f6c8dd0501c51/exe/wd/examples/02_model_collaborative_filtering...rk_movielens': '/mnt/azureml/cr/j/0d490b7a2cbb414d9d2f6c8dd0501c51/exe/wd/examples/06_benchmarks/movielens.ipynb', ...***
output_notebook = 'output.ipynb', kernel_name = 'python3'

    @pytest.mark.notebooks
    @pytest.mark.gpu
    def test_npa_smoke(notebooks, output_notebook, kernel_name):
        notebook_path = notebooks["npa_quickstart"]
>       pm.execute_notebook(
            notebook_path,
            output_notebook,
            kernel_name=kernel_name,
            parameters=dict(epochs=1, seed=42, MIND_type="demo"),
        )

tests/smoke/examples/test_notebooks_gpu.py:190: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/azureml-envs/azureml_7f0e1f5ac7848552bd2cee4736595176/lib/python3.8/site-packages/papermill/execute.py:94: in execute_notebook
    parameter_predefined = _infer_parameters(nb)
/azureml-envs/azureml_7f0e1f5ac7848552bd2cee4736595176/lib/python3.8/site-packages/papermill/inspection.py:42: in _infer_parameters
    language = nb.metadata.kernelspec.language
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = ***'display_name': "Python 3.7.11 64-bit ('tf2': conda)", 'name': 'python3'***
key = 'language'

    def __getattr__(self, key):
        """Get an attr by calling :meth:`dict.__getitem__`.
    
        Like :meth:`__setattr__`, this method converts :exc:`KeyError` to
        :exc:`AttributeError`.
    
        Examples
        --------
        >>> s = Struct(a=10)
        >>> s.a
        10
        >>> type(s.get)
        <... 'builtin_function_or_method'>
        >>> try:
        ...     s.b
        ... except AttributeError:
        ...     print("I don't have that key")
        ...
        I don't have that key
        """
        try:
            result = self[key]
        except KeyError:
>           raise AttributeError(key) from None
E           AttributeError: language

/azureml-envs/azureml_7f0e1f5ac7848552bd2cee4736595176/lib/python3.8/site-packages/nbformat/_struct.py:125: AttributeError
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
