### PR TITLE
Fix benchmarks last cell to store value, not [value]

### DIFF
--- a/examples/06_benchmarks/movielens.ipynb
+++ b/examples/06_benchmarks/movielens.ipynb
@@ -1207,7 +1207,7 @@
             "source": [
                 "# Record results for tests - ignore this cell\n",
                 "for algo in algorithms:\n",
-                "    store_metadata(algo, df_results.loc[df_results[\"Algo\"] == algo, \"nDCG@k\"].values)\n"
+                "    store_metadata(algo, df_results.loc[df_results[\"Algo\"] == algo, \"nDCG@k\"].values[0])\n"
             ]
         }
     ],


### PR DESCRIPTION
### Description
Found the benchmark's last cell was recording `[value]`, not the `value` which was causing another test failures.
my bad 😜
