### PR TITLE
Correct MIND user behavior history construction

### DIFF
--- a/recommenders/models/newsrec/io/mind_all_iterator.py
+++ b/recommenders/models/newsrec/io/mind_all_iterator.py
@@ -146,7 +146,7 @@ class MINDAllIterator(BaseIterator):
 
                 history = [self.nid2index[i] for i in history.split()]
                 history = [0] * (self.his_size - len(history)) + history[
-                    : self.his_size
+                    -self.his_size :
                 ]
 
                 impr_news = [self.nid2index[i.split("-")[0]] for i in impr.split()]

--- a/recommenders/models/newsrec/io/mind_iterator.py
+++ b/recommenders/models/newsrec/io/mind_iterator.py
@@ -119,7 +119,7 @@ class MINDIterator(BaseIterator):
 
                 history = [self.nid2index[i] for i in history.split()]
                 history = [0] * (self.his_size - len(history)) + history[
-                    : self.his_size
+                    -self.his_size :
                 ]
 
                 impr_news = [self.nid2index[i.split("-")[0]] for i in impr.split()]


### PR DESCRIPTION
### Description

This PR fixes #1258 - the construction of user behavior history when loading MIND data.

Changed from

```python
history = [0] * (self.his_size - len(history)) + history[ : self.his_size ]
```

to

```python
history = [0] * (self.his_size - len(history)) + history[ -self.his_size : ]
```

### Related Issues
#1258 

### References
https://github.com/recommenders-team/recommenders/issues/1258#issuecomment-1878878858

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.

cc @yjw1029 