### PR TITLE
Catch import error separately for SUMModel

### DIFF
--- a/tests/smoke/recommenders/recommender/test_deeprec_model.py
+++ b/tests/smoke/recommenders/recommender/test_deeprec_model.py
@@ -20,7 +20,6 @@ try:
     from recommenders.models.deeprec.io.dkn_iterator import DKNTextIterator
     from recommenders.models.deeprec.io.sequential_iterator import SequentialIterator
     from recommenders.models.deeprec.models.sequential.sli_rec import SLI_RECModel
-    from recommenders.models.deeprec.models.sequential.sum import SUMModel
     from recommenders.datasets.amazon_reviews import (
         download_and_extract,
         data_preprocessing,
@@ -30,6 +29,11 @@ try:
 
 except ImportError:
     pass  # disable error while collecting tests for non-gpu environments
+
+try:
+    from recommenders.models.deeprec.models.sequential.sum import SUMModel
+except ImportError:
+    pass  # disable error while collecting tests for SUMModel
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR resolves the issue #2064.  Because TensorFlow breaking changes make the code for SUMModel not work, so the tests relating to `SUMModel` are disabled, and import errors on `SUMModel` should be separately handled, otherwise, the imports following `SUMModel` (such as `ImplicitCF`) will not be run.

https://github.com/recommenders-team/recommenders/blob/96fe3cf13bdb83fe334e6d305b3e31aab5a3ce9f/tests/smoke/recommenders/recommender/test_deeprec_model.py#L10-L32

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
#2064



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
