### PR TITLE
Fix breaking change in sklearn in log_loss 

### DIFF
--- a/examples/00_quick_start/lightgbm_tinycriteo.ipynb
+++ b/examples/00_quick_start/lightgbm_tinycriteo.ipynb
@@ -717,7 +717,7 @@
             "source": [
                 "test_preds = lgb_model.predict(test_x)\n",
                 "auc = roc_auc_score(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
-                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds), eps=1e-12)\n",
+                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
                 "res_basic = {\"auc\": auc, \"logloss\": logloss}\n",
                 "print(res_basic)\n"
             ]
@@ -904,7 +904,7 @@
             ],
             "source": [
                 "auc = roc_auc_score(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
-                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds), eps=1e-12)\n",
+                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
                 "res_optim = {\"auc\": auc, \"logloss\": logloss}\n",
                 "\n",
                 "print(res_optim)"
@@ -959,7 +959,7 @@
             ],
             "source": [
                 "auc = roc_auc_score(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
-                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds), eps=1e-12)\n",
+                "logloss = log_loss(np.asarray(test_y.reshape(-1)), np.asarray(test_preds))\n",
                 "\n",
                 "print({\"auc\": auc, \"logloss\": logloss})"
             ]


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Sklearn removed `eps` parameter in `log_loss`.

See 0.5.0 https://github.com/scikit-learn/scikit-learn/blob/abbaed326c8f0e4a8083979701f01ce581612713/sklearn/metrics/_classification.py#L2829C30-L2829C31

vs
0.4.2: https://github.com/scikit-learn/scikit-learn/blob/8721245511de2f225ff5f9aa5f5fadce663cd4a3/sklearn/metrics/_classification.py#L2822

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
