### PR TITLE
Removed deprecated numpy alias

### DIFF
--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -163,7 +163,7 @@ class LibffmConverter:
         types = df.dtypes
         if not all(
             [
-                x == object or np.issubdtype(x, np.integer) or x == np.float
+                x == object or np.issubdtype(x, np.integer) or x == float
                 for x in types
             ]
         ):


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I reviewed the deprecated numpy aliases usage in the scr folder, but not the notebooks. They were deprecated in numpy 1.20 and removed in 1.24

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
- #2112 

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->
- https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
- https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
