### PR TITLE
Fix ImplicitCF failing if not using stratified split #2024

### DIFF
--- a/recommenders/models/deeprec/DataModel/ImplicitCF.py
+++ b/recommenders/models/deeprec/DataModel/ImplicitCF.py
@@ -80,6 +80,7 @@ class ImplicitCF(object):
             user_idx = df[[self.col_user]].drop_duplicates().reindex()
             user_idx[self.col_user + "_idx"] = np.arange(len(user_idx))
             self.n_users = len(user_idx)
+            self.n_users_in_train = train[self.col_user].nunique()
             self.user_idx = user_idx
 
             self.user2id = dict(
@@ -210,7 +211,7 @@ class ImplicitCF(object):
                 if neg_id not in x:
                     return neg_id
 
-        indices = range(self.n_users)
+        indices = range(self.n_users_in_train)
         if self.n_users < batch_size:
             users = [random.choice(indices) for _ in range(batch_size)]
         else:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Added a variable called `n_users_in_train` to allow ImplicitCF to work even if a user is in test but not in train.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
- #2024

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
