### PR TITLE
Pin numpy version to 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,12 @@
 requires = [
     "setuptools>=52",
     "wheel>=0.36",
-    "numpy>=1.15",
+    "numpy>=1.15,<2",
 ]
 dependencies = [
     "setuptools>=52",
     "wheel>=0.36",
-    "numpy>=1.15",
+    "numpy>=1.15,<2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Numpy has recently been updated to 2.0.0, with multiple breaking changes. Until the library usage is migrated, I pinned down the version to <2.

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->
- https://numpy.org/news/#numpy-200-released
- https://numpy.org/devdocs/release/2.0.0-notes.html

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
