### PR TITLE
Remove LightFM from core package

### DIFF
--- a/examples/02_model_collaborative_filtering/lightfm_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/lightfm_deep_dive.ipynb
@@ -22,6 +22,8 @@
             "source": [
                 "This notebook explains the concept of a Factorization Machine based model for recommendation, it also outlines the steps to construct a pure matrix factorization and a Factorization Machine using the [LightFM](https://github.com/lyst/lightfm) package. It also demonstrates how to extract both user and item affinity from a fitted model.\n",
                 "\n",
+                "*NOTE: LightFM is not available in the core package of Recommenders, to run this notebook, install the experimental package with `pip install recommenders[experimental]`.*\n",
+                "\n",
                 "## 1. Factorization Machine model\n",
                 "\n",
                 "### 1.1 Background\n",

--- a/recommenders/datasets/movielens.py
+++ b/recommenders/datasets/movielens.py
@@ -582,7 +582,7 @@ def unique_columns(df, *, columns):
     return not df[columns].duplicated().any()
 
 
-class MockMovielensSchema(pa.SchemaModel):
+class MockMovielensSchema(pa.DataFrameModel):
     """
     Mock dataset schema to generate fake data for testing purpose.
     This schema is configured to mimic the Movielens dataset

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ install_requires = [
     "category-encoders>=2.6.0,<3",  # requires packaging
     "cornac>=1.15.2,<2",  # requires packaging, tqdm
     "hyperopt>=0.2.7,<1",
-    "lightfm>=1.17,<2",  # requires requests
     "lightgbm>=4.0.0,<5",
     "locust>=2.12.2,<3",  # requires jinja2
     "memory-profiler>=0.61.0,<1",
@@ -80,6 +79,7 @@ extras_require["experimental"] = [
     # nni needs to be upgraded
     "nni==1.5",
     "pymanopt>=0.2.5",
+    "lightfm>=1.17,<2",
 ]
 
 # The following dependency can be installed as below, however PyPI does not allow direct URLs.

--- a/tests/ci/azureml_tests/test_groups.py
+++ b/tests/ci/azureml_tests/test_groups.py
@@ -47,8 +47,6 @@ nightly_test_groups = {
         "tests/functional/examples/test_notebooks_python.py::test_geoimc_functional",  # 1006.19s
         #
         "tests/functional/examples/test_notebooks_python.py::test_benchmark_movielens_cpu",  # 58s
-        #
-        "tests/functional/examples/test_notebooks_python.py::test_lightfm_functional",
     ],
     "group_cpu_003": [  # Total group time: 2253s
         "tests/data_validation/recommenders/datasets/test_criteo.py::test_download_criteo_sample",  # 1.05s
@@ -237,10 +235,6 @@ pr_gate_test_groups = {
         "tests/unit/recommenders/models/test_geoimc.py::test_imcproblem",
         "tests/unit/recommenders/models/test_geoimc.py::test_inferer_init",
         "tests/unit/recommenders/models/test_geoimc.py::test_inferer_infer",
-        "tests/unit/recommenders/models/test_lightfm_utils.py::test_interactions",
-        "tests/unit/recommenders/models/test_lightfm_utils.py::test_fitting",
-        "tests/unit/recommenders/models/test_lightfm_utils.py::test_sim_users",
-        "tests/unit/recommenders/models/test_lightfm_utils.py::test_sim_items",
         "tests/unit/recommenders/models/test_sar_singlenode.py::test_init",
         "tests/unit/recommenders/models/test_sar_singlenode.py::test_fit",
         "tests/unit/recommenders/models/test_sar_singlenode.py::test_predict",
@@ -452,4 +446,15 @@ pr_gate_test_groups = {
         "tests/unit/examples/test_notebooks_gpu.py::test_xdeepfm",
         "tests/unit/examples/test_notebooks_gpu.py::test_gpu_vm",
     ],
+}
+
+# Experimental are additional test groups that require to install extra dependencies: pip install .[experimental]
+experimental_test_groups = {
+    "group_cpu_001": [
+        "tests/unit/recommenders/models/test_lightfm_utils.py::test_interactions",
+        "tests/unit/recommenders/models/test_lightfm_utils.py::test_fitting",
+        "tests/unit/recommenders/models/test_lightfm_utils.py::test_sim_users",
+        "tests/unit/recommenders/models/test_lightfm_utils.py::test_sim_items",
+        "tests/functional/examples/test_notebooks_python.py::test_lightfm_functional",
+    ]
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
It seems LightFM is not supported anymore. It is currently blocking the support of Python 3.12 #2097. @daviddavo even fixed the problem in their repo https://github.com/lyst/lightfm/pull/710 but there is no response from the maintainers.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
#2115

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.
