### PR TITLE
Update timeout of AzureML tests and add explicit runner in Ubuntu 24.04

### DIFF
--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -63,7 +63,8 @@ jobs:
   execute-tests:
     needs: get-test-groups
     name: ${{ join(matrix.*, ', ') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120 
     permissions:
       id-token: write # This is required for requesting the JWT
     strategy:

--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   get-test-groups:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -63,7 +63,8 @@ jobs:
   execute-tests:
     needs: get-test-groups
     name: ${{ join(matrix.*, ', ') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120 
     permissions:
       id-token: write # This is required for requesting the JWT
     strategy:

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   get-test-groups:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/azureml-release-pipeline.yml
+++ b/.github/workflows/azureml-release-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
     secrets: inherit
 
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [unit-test-workflow, cpu-nightly-workflow, gpu-nightly-workflow, spark-nightly-workflow]
     steps:
       - name: Check out repository code

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -43,7 +43,7 @@ on:
 
 jobs:
   get-test-groups:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -62,7 +62,8 @@ jobs:
   execute-tests:
     needs: get-test-groups
     name: ${{ join(matrix.*, ', ') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120 
     permissions:
       id-token: write # This is required for requesting the JWT
     strategy:

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -52,7 +52,8 @@ jobs:
   execute-tests:
     needs: get-test-groups
     name: ${{ join(matrix.*, ', ') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120 
     permissions:
       id-token: write # This is required for requesting the JWT
     strategy:

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   get-test-groups:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -36,7 +36,7 @@ jobs:
     # Test pysarplus with different versions of Python.
     # Package pysarplus and upload as GitHub workflow artifact when merged into
     # the main branch.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I want to limit each of the computations to 2h, but not all the tests of 1 category. For example, each test process should take less than 2h, but the whole GPU tests can take longer because maybe they are waiting for a free VM.

I used https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes but if it doesn't work I would need to do the timeout within the steps: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Related to this discussion: https://github.com/recommenders-team/recommenders/pull/2189#discussion_r1844827275

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.
