### PR TITLE
Install sbt for sarplus tests

### DIFF
--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -8,7 +8,7 @@
 #   * GitHub Actions workflow templates
 #       + [python package](https://github.com/actions/starter-workflows/blob/main/ci/python-package.yml)
 #       + [scala](https://github.com/actions/starter-workflows/blob/main/ci/scala.yml)
-#   * [GitHub hosted runner - Ubuntu 20.04 LTS](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md)
+#   * [GitHub hosted runner - Ubuntu 24.04 LTS](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)
 #   * [Azure Databricks runtime releases](https://docs.microsoft.com/en-us/azure/databricks/release-notes/runtime/releases)
 #   * [Azure Synapse Analytics runtimes](https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-version-support)
 
@@ -52,6 +52,14 @@ jobs:
         run: |
           python -m pip install -U build cibuildwheel pip twine
           python -m pip install -U flake8 pytest pytest-cov scikit-learn
+
+          # Install sbt
+          # See https://github.com/yokra9/akka-http-example/pull/119/files
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          sudo apt-get update
+          sudo apt-get install sbt
 
       - name: Lint with flake8
         run: |
@@ -132,6 +140,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install sbt
+        run: |
+          # See https://github.com/yokra9/akka-http-example/pull/119/files
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+          echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          sudo apt-get update
+          sudo apt-get install sbt
 
       - name: Test
         run: |


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR installs sbt in the testing workflow of sarplus, because GitHub hosted runner [ubuntu-24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md) removed the installation of sbt, [making the tests for sarplus fail](https://github.com/recommenders-team/recommenders/actions/runs/11889835469/job/33127202507).

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->
* https://github.com/actions/runner-images/issues/10636#issuecomment-2377837332
* https://github.com/yokra9/akka-http-example/pull/119

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [X] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
