### PR TITLE
Use cornac 2.3.0 for Python 3.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ if HASH is not None:
 
 install_requires = [
     "category-encoders>=2.6.0,<3",  # requires packaging
-    "cornac>=1.15.2,<3",  # requires packaging, tqdm
+    "cornac>=1.15.2,<=2.2.2;python_version<='3.8'",
+    "cornac>=2.3.0,<3;python_version>='3.9'",  # requires packaging, tqdm
     "hyperopt>=0.2.7,<1",
     "lightgbm>=4.0.0,<5",
     "locust>=2.12.2,<3",  # requires jinja2


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The latest version of [cornac 2.3.0](https://pypi.org/project/cornac/#files) does not provide built distributions for Python 3.8.  This PR set cornac to 2.2.2 for Python 3.8.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
* #2203

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
