### PR TITLE
Set NumPy < 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
     "nltk>=3.8.1,<4",  # requires tqdm
     "notebook>=6.5.5,<8",  # requires ipykernel, jinja2, jupyter, nbconvert, nbformat, packaging, requests
     "numba>=0.57.0,<1",
+    "numpy<2.0.0",  # See https://github.com/recommenders-team/recommenders/issues/2224
     "pandas>2.0.0,<3.0.0",  # requires numpy
     "pandera[strategies]>=0.6.5,<0.18;python_version<='3.8'",  # For generating fake datasets
     "pandera[strategies]>=0.15.0;python_version>='3.9'",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The file [`surprise/similarities.pyx`](https://github.com/NicolasHug/Surprise/blob/master/surprise/similarities.pyx) in the package [`scikit-surprise`](https://pypi.org/project/scikit-surprise/) doesn't work with NumPy 2.x.  This PR sets `numpy<2.0.0` to resolve the issue.  This constraint needs to be removed after a newer version of `scimitar-surprise` is released.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
* https://github.com/recommenders-team/recommenders/issues/2224

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
