### PR TITLE
Change Movielens URL from https to http

### DIFF
--- a/examples/01_prepare_data/data_split.ipynb
+++ b/examples/01_prepare_data/data_split.ipynb
@@ -73,7 +73,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "DATA_URL = \"https://files.grouplens.org/datasets/movielens/ml-100k/u.data\"\n",
+                "DATA_URL = \"http://files.grouplens.org/datasets/movielens/ml-100k/u.data\"\n",
                 "DATA_PATH = \"ml-100k.data\"\n",
                 "\n",
                 "COL_USER = \"UserId\"\n",

--- a/recommenders/datasets/movielens.py
+++ b/recommenders/datasets/movielens.py
@@ -159,7 +159,7 @@ def load_pandas_df(
 ):
     """Loads the MovieLens dataset as pd.DataFrame.
 
-    Download the dataset from https://files.grouplens.org/datasets/movielens, unzip, and load.
+    Download the dataset from http://files.grouplens.org/datasets/movielens, unzip, and load.
     To load movie information only, you can use load_item_df function.
 
     Args:
@@ -304,7 +304,7 @@ def _load_item_df(size, item_datapath, movie_col, title_col, genres_col, year_co
     genres_header_100k = None
     if genres_col is not None:
         # 100k data's movie genres are encoded as a binary array (the last 19 fields)
-        # For details, see https://files.grouplens.org/datasets/movielens/ml-100k-README.txt
+        # For details, see http://files.grouplens.org/datasets/movielens/ml-100k-README.txt
         if size == "100k":
             genres_header_100k = [*(str(i) for i in range(19))]
             item_header.extend(genres_header_100k)
@@ -366,7 +366,7 @@ def load_spark_df(
 ):
     """Loads the MovieLens dataset as `pyspark.sql.DataFrame`.
 
-    Download the dataset from https://files.grouplens.org/datasets/movielens, unzip, and load as `pyspark.sql.DataFrame`.
+    Download the dataset from http://files.grouplens.org/datasets/movielens, unzip, and load as `pyspark.sql.DataFrame`.
 
     To load movie information only, you can use `load_item_df` function.
 
@@ -552,7 +552,7 @@ def download_movielens(size, dest_path):
     if size not in DATA_FORMAT:
         raise ValueError(f"Size: {size}. " + ERROR_MOVIE_LENS_SIZE)
 
-    url = "https://files.grouplens.org/datasets/movielens/ml-" + size + ".zip"
+    url = "http://files.grouplens.org/datasets/movielens/ml-" + size + ".zip"
     dirs, file = os.path.split(dest_path)
     maybe_download(url, file, work_directory=dirs)
 
@@ -587,7 +587,7 @@ class MockMovielensSchema(pa.DataFrameModel):
     Mock dataset schema to generate fake data for testing purpose.
     This schema is configured to mimic the Movielens dataset
 
-    https://files.grouplens.org/datasets/movielens/ml-100k/
+    http://files.grouplens.org/datasets/movielens/ml-100k/
 
     Dataset schema and generation is configured using pandera.
     Please see https://pandera.readthedocs.io/en/latest/schema_models.html


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The SSL certificate for the Movielens website seems to expire recently, making [the tests](https://github.com/recommenders-team/recommenders/actions/runs/17032151183/job/48280028612?pr=2098#step:3:3168) to download Movielens datasets fail with the following error:

> SSLError: HTTPSConnectionPool(host='files.grouplens.org', port=443): Max retries exceeded with url: /datasets/movielens/ml-100k.zip (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1149)')))

This PR removes the SSL verification by changing **HTTPS** to **HTTP**.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [X] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
