### PR TITLE
fix: CONTRIBUTING.md link in the Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,24 @@
 ### Description
+
 <!--- Describe your changes in detail -->
 <!--- Why is this change required? What problem does it solve? -->
 
-
 ### Related Issues
+
 <!--- If it fixes an open issue, please link to the issue here. -->
 
-
 ### References
+
 <!--- References would be helpful to understand the changes. -->
 <!--- References can be books, links, etc. -->
 
-
 ### Checklist:
+
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
+
+- [ ] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
 - [ ] I have added tests covering my contributions.
 - [ ] I have updated the documentation accordingly.
-- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
+- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
 - [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixes link to CONTRIBUTING.md. Previously linked to a Github compare link that didn't show the file correctly.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
#2265 

### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`. 
- [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.
