### PR TITLE
Fix mutable default argument in Keras callback methods

### DIFF
--- a/recommenders/models/vae/multinomial_vae.py
+++ b/recommenders/models/vae/multinomial_vae.py
@@ -16,13 +16,17 @@ from tensorflow.keras.callbacks import ReduceLROnPlateau, Callback
 class LossHistory(Callback):
     """This class is used for saving the validation loss and the training loss per epoch."""
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise the lists where the loss of training and validation will be saved."""
+        if logs is None:
+            logs = {}
         self.losses = []
         self.val_losses = []
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
         """Save the loss of training and validation set at the end of each epoch."""
+        if logs is None:
+            logs = {}
         self.losses.append(logs.get("loss"))
         self.val_losses.append(logs.get("val_loss"))
 
@@ -62,8 +66,10 @@ class Metrics(Callback):
         # Options to save the weights of the model for future use
         self.save_path = save_path
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise the list for validation NDCG@k."""
+        if logs is None:
+            logs = {}
         self._data = []
 
     def recommend_k_items(self, x, k, remove_seen=True):
@@ -100,13 +106,15 @@ class Metrics(Callback):
 
         return top_scores
 
-    def on_epoch_end(self, batch, logs={}):
+    def on_epoch_end(self, batch, logs=None):
         """At the end of each epoch calculate NDCG@k of the validation set.
 
         If the model performance is improved, the model weights are saved.
         Update the list of validation NDCG@k by adding obtained value
 
         """
+        if logs is None:
+            logs = {}
         # recommend top k items based on training part of validation set
         top_k = self.recommend_k_items(x=self.val_tr, k=self.k, remove_seen=True)
 
@@ -158,12 +166,16 @@ class AnnealingCallback(Callback):
         # total annealing steps
         self.total_anneal_steps = total_anneal_steps
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise a list in which the beta value will be saved at the end of each epoch."""
+        if logs is None:
+            logs = {}
         self._beta = []
 
-    def on_batch_end(self, epoch, logs={}):
+    def on_batch_end(self, epoch, logs=None):
         """At the end of each batch the beta should is updated until it reaches the values of anneal cap."""
+        if logs is None:
+            logs = {}
         self.update_count = self.update_count + 1
 
         new_beta = min(
@@ -172,8 +184,10 @@ class AnnealingCallback(Callback):
 
         K.set_value(self.beta, new_beta)
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
         """At the end of each epoch save the value of beta in _beta list."""
+        if logs is None:
+            logs = {}
         tmp = K.eval(self.beta)
         self._beta.append(tmp)
 

--- a/recommenders/models/vae/multinomial_vae.py
+++ b/recommenders/models/vae/multinomial_vae.py
@@ -18,15 +18,13 @@ class LossHistory(Callback):
 
     def on_train_begin(self, logs=None):
         """Initialise the lists where the loss of training and validation will be saved."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         self.losses = []
         self.val_losses = []
 
     def on_epoch_end(self, epoch, logs=None):
         """Save the loss of training and validation set at the end of each epoch."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         self.losses.append(logs.get("loss"))
         self.val_losses.append(logs.get("val_loss"))
 
@@ -68,8 +66,7 @@ class Metrics(Callback):
 
     def on_train_begin(self, logs=None):
         """Initialise the list for validation NDCG@k."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         self._data = []
 
     def recommend_k_items(self, x, k, remove_seen=True):
@@ -113,8 +110,7 @@ class Metrics(Callback):
         Update the list of validation NDCG@k by adding obtained value
 
         """
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         # recommend top k items based on training part of validation set
         top_k = self.recommend_k_items(x=self.val_tr, k=self.k, remove_seen=True)
 
@@ -168,14 +164,12 @@ class AnnealingCallback(Callback):
 
     def on_train_begin(self, logs=None):
         """Initialise a list in which the beta value will be saved at the end of each epoch."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         self._beta = []
 
     def on_batch_end(self, epoch, logs=None):
         """At the end of each batch the beta should is updated until it reaches the values of anneal cap."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         self.update_count = self.update_count + 1
 
         new_beta = min(
@@ -186,8 +180,7 @@ class AnnealingCallback(Callback):
 
     def on_epoch_end(self, epoch, logs=None):
         """At the end of each epoch save the value of beta in _beta list."""
-        if logs is None:
-            logs = {}
+        logs = logs or {}
         tmp = K.eval(self.beta)
         self._beta.append(tmp)
 

--- a/recommenders/models/vae/standard_vae.py
+++ b/recommenders/models/vae/standard_vae.py
@@ -17,13 +17,17 @@ from recommenders.evaluation.python_evaluation import ndcg_at_k
 class LossHistory(Callback):
     """This class is used for saving the validation loss and the training loss per epoch."""
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise the lists where the loss of training and validation will be saved."""
+        if logs is None:
+            logs = {}
         self.losses = []
         self.val_losses = []
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
         """Save the loss of training and validation set at the end of each epoch."""
+        if logs is None:
+            logs = {}
         self.losses.append(logs.get("loss"))
         self.val_losses.append(logs.get("val_loss"))
 
@@ -63,8 +67,10 @@ class Metrics(Callback):
         # Options to save the weights of the model for future use
         self.save_path = save_path
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise the list for validation NDCG@k."""
+        if logs is None:
+            logs = {}
         self._data = []
 
     def recommend_k_items(self, x, k, remove_seen=True):
@@ -101,11 +107,13 @@ class Metrics(Callback):
 
         return top_scores
 
-    def on_epoch_end(self, batch, logs={}):
+    def on_epoch_end(self, batch, logs=None):
         """At the end of each epoch calculate NDCG@k of the validation set.
         If the model performance is improved, the model weights are saved.
         Update the list of validation NDCG@k by adding obtained value.
         """
+        if logs is None:
+            logs = {}
         # recommend top k items based on training part of validation set
         top_k = self.recommend_k_items(x=self.val_tr, k=self.k, remove_seen=True)
 
@@ -158,12 +166,16 @@ class AnnealingCallback(Callback):
         # total annealing steps
         self.total_anneal_steps = total_anneal_steps
 
-    def on_train_begin(self, logs={}):
+    def on_train_begin(self, logs=None):
         """Initialise a list in which the beta value will be saved at the end of each epoch."""
+        if logs is None:
+            logs = {}
         self._beta = []
 
-    def on_batch_end(self, epoch, logs={}):
+    def on_batch_end(self, epoch, logs=None):
         """At the end of each batch the beta should is updated until it reaches the values of anneal cap."""
+        if logs is None:
+            logs = {}
         self.update_count = self.update_count + 1
 
         new_beta = min(
@@ -172,8 +184,10 @@ class AnnealingCallback(Callback):
 
         K.set_value(self.beta, new_beta)
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
         """At the end of each epoch save the value of beta in _beta list."""
+        if logs is None:
+            logs = {}
         tmp = K.eval(self.beta)
         self._beta.append(tmp)
 


### PR DESCRIPTION
## Summary

- Replace `logs={}` with `logs=None` and add `if logs is None: logs = {}` guard in all Keras callback methods in `multinomial_vae.py` and `standard_vae.py`
- Using a mutable default argument like `{}` is a well-known Python anti-pattern ([W0102](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/dangerous-default-value.html)) — the same dict object is shared across all calls, which can lead to unexpected state leakage between invocations
- This also aligns with the Keras `Callback` base class, which uses `logs=None` as the default

## Changes

**`recommenders/models/vae/multinomial_vae.py`** — 7 instances fixed:
- `LossHistory.on_train_begin` (line 19)
- `LossHistory.on_epoch_end` (line 24)
- `Metrics.on_train_begin` (line 65)
- `Metrics.on_epoch_end` (line 103)
- `AnnealingCallback.on_train_begin` (line 161)
- `AnnealingCallback.on_batch_end` (line 165)
- `AnnealingCallback.on_epoch_end` (line 175)

**`recommenders/models/vae/standard_vae.py`** — 7 instances fixed:
- `LossHistory.on_train_begin` (line 20)
- `LossHistory.on_epoch_end` (line 25)
- `Metrics.on_train_begin` (line 66)
- `Metrics.on_epoch_end` (line 104)
- `AnnealingCallback.on_train_begin` (line 161)
- `AnnealingCallback.on_batch_end` (line 165)
- `AnnealingCallback.on_epoch_end` (line 175)

## Test plan

- [ ] Verify all `logs={}` replaced with `logs=None` + guard
- [ ] No functional change — behavior is identical when `logs` is passed by caller (which Keras always does)
- [ ] Existing VAE notebook tests should pass without modification