### PR TITLE
feat: add lightgbm ranker

### DIFF
--- a/examples/00_quick_start/lightgbm_ranker.ipynb
+++ b/examples/00_quick_start/lightgbm_ranker.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LightGBMRanker: A Reusable Ranker for Recommendation\n",
+    "\n",
+    "This notebook demonstrates how to build a ranking pipeline for recommendations using `LightGBMRanker`, a utility class that wraps LightGBM training, inference, save, and load into a single sklearn-like interface.\n",
+    "\n",
+    "```python\n",
+    "from recommenders.models.lightgbm import LightGBMRanker\n",
+    "\n",
+    "ranker = LightGBMRanker(params={...})\n",
+    "ranker.fit(train_x, train_y, valid_x, valid_y)\n",
+    "scores  = ranker.predict(test_x)\n",
+    "ranker.save(\"model.lgb\")\n",
+    "\n",
+    "loaded  = LightGBMRanker.load(\"model.lgb\")\n",
+    "scores  = loaded.predict(test_x)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Imports and Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import numpy as np\n",
+    "from tempfile import TemporaryDirectory\n",
+    "from sklearn.metrics import roc_auc_score, log_loss\n",
+    "\n",
+    "import recommenders.datasets.criteo as criteo\n",
+    "from recommenders.models.lightgbm import LightGBMRanker\n",
+    "from recommenders.models.lightgbm.lightgbm_utils import NumEncoder\n",
+    "\n",
+    "print(f\"Python: {sys.version}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Data settings\n",
+    "SIZE      = \"sample\"  # 'sample' | 'full'\n",
+    "LABEL_COL = \"Label\"\n",
+    "NUME_COLS = [f\"I{i}\" for i in range(1, 14)]\n",
+    "CATE_COLS = [f\"C{i}\" for i in range(1, 27)]\n",
+    "HEADER    = [LABEL_COL] + NUME_COLS + CATE_COLS\n",
+    "\n",
+    "# LightGBMRanker parameters (merged on top of DEFAULT_PARAMS)\n",
+    "PARAMS = {\n",
+    "    \"objective\": \"binary\",\n",
+    "    \"metric\": \"auc\",\n",
+    "    \"num_leaves\": 64,\n",
+    "    \"learning_rate\": 0.15,\n",
+    "    \"feature_fraction\": 0.8,\n",
+    "    \"num_threads\": 4,\n",
+    "}\n",
+    "NUM_BOOST_ROUND       = 100\n",
+    "EARLY_STOPPING_ROUNDS = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Data Preparation\n",
+    "\n",
+    "We use the [Criteo dataset](https://www.kaggle.com/c/criteo-display-ad-challenge) — a standard industry benchmark for CTR prediction — and split it chronologically into train (80%), validation (10%), and test (10%) sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as tmp:\n",
+    "    all_data = criteo.load_pandas_df(size=SIZE, local_cache_path=tmp, header=HEADER)\n",
+    "\n",
+    "length     = len(all_data)\n",
+    "train_data = all_data.iloc[: int(0.8 * length)]\n",
+    "valid_data = all_data.iloc[int(0.8 * length) : int(0.9 * length)]\n",
+    "test_data  = all_data.iloc[int(0.9 * length) :]\n",
+    "\n",
+    "print(f\"train: {len(train_data):,}  valid: {len(valid_data):,}  test: {len(test_data):,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Feature Encoding (NumEncoder)\n",
+    "\n",
+    "`NumEncoder` converts all categorical columns into dense numerical features through three steps:\n",
+    "1. **Low-frequency filtering** — rare categories become `<LESS>`, missing values become `<UNK>`.\n",
+    "2. **Sequential target & count encoding** — encodes each sample using statistics from previous samples only (no label leakage).\n",
+    "3. **Binary encoding** — the ordinal-encoded category values are expanded into bit vectors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "encoder = NumEncoder(CATE_COLS, NUME_COLS, LABEL_COL)\n",
+    "\n",
+    "train_x, train_y = encoder.fit_transform(train_data)\n",
+    "valid_x, valid_y = encoder.transform(valid_data)\n",
+    "test_x,  test_y  = encoder.transform(test_data)\n",
+    "\n",
+    "print(f\"train_x: {train_x.shape}  valid_x: {valid_x.shape}  test_x: {test_x.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Training (LightGBMRanker.fit)\n",
+    "\n",
+    "Passing a validation set enables early stopping automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranker = LightGBMRanker(\n",
+    "    params=PARAMS,\n",
+    "    num_boost_round=NUM_BOOST_ROUND,\n",
+    "    early_stopping_rounds=EARLY_STOPPING_ROUNDS,\n",
+    ")\n",
+    "\n",
+    "ranker.fit(train_x, train_y, valid_x=valid_x, valid_y=valid_y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Inference and Evaluation (LightGBMRanker.predict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = ranker.predict(test_x)\n",
+    "\n",
+    "auc     = roc_auc_score(test_y.reshape(-1), scores)\n",
+    "logloss = log_loss(test_y.reshape(-1), scores)\n",
+    "\n",
+    "print(f\"AUC:     {auc:.4f}\")\n",
+    "print(f\"LogLoss: {logloss:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Top-K Ranking Example\n",
+    "\n",
+    "In a real recommendation pipeline, you score all candidate items per user and sort by descending score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "result_df = pd.DataFrame({\n",
+    "    \"score\": scores,\n",
+    "    \"label\": test_y.reshape(-1),\n",
+    "})\n",
+    "\n",
+    "top5 = result_df.nlargest(5, \"score\")\n",
+    "print(\"Top-5 recommendations (sorted by score):\")\n",
+    "display(top5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Save and Load (save / load)\n",
+    "\n",
+    "A model saved with `save()` can be restored with `LightGBMRanker.load()` and produces identical predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as tmp:\n",
+    "    model_path = os.path.join(tmp, \"ranker.lgb\")\n",
+    "\n",
+    "    ranker.save(model_path)\n",
+    "\n",
+    "    loaded_ranker = LightGBMRanker.load(model_path)\n",
+    "    loaded_scores = loaded_ranker.predict(test_x)\n",
+    "\n",
+    "assert np.allclose(scores, loaded_scores), \"Predictions differ after save/load!\"\n",
+    "print(\"Save/load verified: predictions are identical.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Learning-to-Rank (lambdarank) Mode\n",
+    "\n",
+    "For query-level ranking (e.g. ranking items per user session), switch the objective to `lambdarank` and supply a group array that specifies how many items belong to each query.\n",
+    "\n",
+    "```python\n",
+    "import lightgbm as lgb\n",
+    "from recommenders.models.lightgbm import LightGBMRanker\n",
+    "\n",
+    "ltr_params = {\n",
+    "    \"objective\": \"lambdarank\",\n",
+    "    \"metric\": \"ndcg\",\n",
+    "    \"ndcg_eval_at\": [5, 10],\n",
+    "    \"num_leaves\": 64,\n",
+    "    \"learning_rate\": 0.05,\n",
+    "}\n",
+    "\n",
+    "# train_group: list of item counts per user, e.g. [3, 5, 4]\n",
+    "lgb_train = lgb.Dataset(train_x, train_y.reshape(-1))\n",
+    "lgb_train.set_group(train_group)\n",
+    "\n",
+    "ltr_ranker = LightGBMRanker(params=ltr_params, num_boost_round=200)\n",
+    "ltr_ranker.model = lgb.train(ltr_params, lgb_train, num_boost_round=200)\n",
+    "\n",
+    "ltr_scores = ltr_ranker.predict(test_x)\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/recommenders/models/lightgbm/lightgbm_utils.py
+++ b/recommenders/models/lightgbm/lightgbm_utils.py
@@ -8,6 +8,8 @@ from tqdm import tqdm
 import collections
 import gc
 
+import lightgbm as lgb
+
 
 def unpackbits(x, num_bits):
     """Convert a decimal value numpy.ndarray into multi-binary value numpy.ndarray ([1,2]->[[0,1],[1,0]])
@@ -205,3 +207,139 @@ class NumEncoder(object):
         gc.collect()
         vld_x = np.array(rows)
         return vld_x, vld_y
+
+
+class LightGBMRanker:
+    """LightGBM-based ranker for recommendation tasks.
+
+    Wraps LightGBM training, inference, save, and load into a single class
+    that follows a sklearn-like interface. Supports both binary classification
+    (CTR prediction) and learning-to-rank objectives (lambdarank, etc.).
+
+    Example::
+
+        ranker = LightGBMRanker(params={"objective": "binary", "metric": "auc"})
+        ranker.fit(train_x, train_y, valid_x, valid_y)
+        scores = ranker.predict(test_x)
+        ranker.save("model.lgb")
+
+        loaded = LightGBMRanker.load("model.lgb")
+        scores = loaded.predict(test_x)
+    """
+
+    DEFAULT_PARAMS = {
+        "task": "train",
+        "boosting_type": "gbdt",
+        "objective": "binary",
+        "metric": "auc",
+        "num_leaves": 64,
+        "min_data": 20,
+        "boost_from_average": True,
+        "num_threads": 4,
+        "feature_fraction": 0.8,
+        "learning_rate": 0.15,
+    }
+
+    def __init__(self, params=None, num_boost_round=100, early_stopping_rounds=20):
+        """Constructor.
+
+        Args:
+            params (dict): LightGBM parameters. Merged with DEFAULT_PARAMS; keys
+                in ``params`` take precedence.
+            num_boost_round (int): Maximum number of boosting iterations.
+            early_stopping_rounds (int): Stop training if no improvement for this
+                many rounds on the validation set. Ignored when no validation set
+                is provided.
+        """
+        self.params = {**self.DEFAULT_PARAMS, **(params or {})}
+        self.num_boost_round = num_boost_round
+        self.early_stopping_rounds = early_stopping_rounds
+        self.model = None
+
+    def fit(self, train_x, train_y, valid_x=None, valid_y=None, categorical_feature=None):
+        """Train the ranker.
+
+        Args:
+            train_x (numpy.ndarray or pandas.DataFrame): Training features.
+            train_y (numpy.ndarray): Training labels, shape ``(n,)`` or ``(n, 1)``.
+            valid_x (numpy.ndarray or pandas.DataFrame, optional): Validation features.
+            valid_y (numpy.ndarray, optional): Validation labels.
+            categorical_feature (list, optional): Column names or indices of
+                categorical features passed to LightGBM. Defaults to ``"auto"``.
+
+        Returns:
+            LightGBMRanker: self
+        """
+        cat_feat = categorical_feature or "auto"
+        lgb_train = lgb.Dataset(
+            train_x, train_y.reshape(-1), params=self.params, categorical_feature=cat_feat
+        )
+
+        valid_sets = [lgb_train]
+        callbacks = []
+        if valid_x is not None and valid_y is not None:
+            lgb_valid = lgb.Dataset(
+                valid_x,
+                valid_y.reshape(-1),
+                reference=lgb_train,
+                categorical_feature=cat_feat,
+            )
+            valid_sets.append(lgb_valid)
+            if self.early_stopping_rounds:
+                callbacks.append(lgb.early_stopping(self.early_stopping_rounds))
+
+        self.model = lgb.train(
+            self.params,
+            lgb_train,
+            num_boost_round=self.num_boost_round,
+            valid_sets=valid_sets,
+            callbacks=callbacks or None,
+        )
+        return self
+
+    def predict(self, x):
+        """Return ranking scores for the given features.
+
+        Args:
+            x (numpy.ndarray or pandas.DataFrame): Input features.
+
+        Returns:
+            numpy.ndarray: Predicted scores, shape ``(n,)``.
+        """
+        if self.model is None:
+            raise RuntimeError("Model is not trained. Call fit() or load() first.")
+        return self.model.predict(x)
+
+    def save(self, path):
+        """Save the trained model to a file.
+
+        Args:
+            path (str): Destination file path (e.g. ``"model.lgb"``).
+        """
+        if self.model is None:
+            raise RuntimeError("No trained model to save.")
+        self.model.save_model(path)
+        logging.info("LightGBMRanker model saved to %s", path)
+
+    @classmethod
+    def load(cls, path, params=None, num_boost_round=100, early_stopping_rounds=20):
+        """Load a previously saved model from a file.
+
+        Args:
+            path (str): Path to the saved model file.
+            params (dict, optional): LightGBM parameters stored on the instance
+                (not used for inference, but available for reference).
+            num_boost_round (int): Stored on the instance for reference.
+            early_stopping_rounds (int): Stored on the instance for reference.
+
+        Returns:
+            LightGBMRanker: Instance with the loaded model ready for prediction.
+        """
+        ranker = cls(
+            params=params,
+            num_boost_round=num_boost_round,
+            early_stopping_rounds=early_stopping_rounds,
+        )
+        ranker.model = lgb.Booster(model_file=path)
+        logging.info("LightGBMRanker model loaded from %s", path)
+        return ranker


### PR DESCRIPTION
### Description

Introduces `LightGBMRanker`, a reusable wrapper class for LightGBM-based ranking in recommendation pipelines. The class follows a sklearn-like interface and consolidates training, inference, model persistence, and loading into a single object.

Previously, model training, saving, and loading were always written inline in notebooks with no shared abstraction. `LightGBMRanker` eliminates this repetition and makes the ranker easy to reuse across recommendation workflows.

**`recommenders/models/lightgbm/lightgbm_utils.py`**
- Added `LightGBMRanker` class:
  - `fit(train_x, train_y, valid_x, valid_y)` — trains the model; enables early stopping automatically when a validation set is provided
  - `predict(x)` — returns ranking scores as a numpy array
  - `save(path)` — saves the trained booster to a file
  - `LightGBMRanker.load(path)` — class method that restores a model from file
- Supports binary classification (`objective: binary`) and learning-to-rank objectives (`lambdarank`, etc.)
- Merges user-supplied params with sensible defaults via `DEFAULT_PARAMS`

**`recommenders/models/lightgbm/__init__.py`**
- Exports `LightGBMRanker` and `NumEncoder` for top-level import:
  ```python
  from recommenders.models.lightgbm import LightGBMRanker
