### PR TITLE
fix: support Scala 2.13+ by replacing paradise plugin with -Ymacro-annotations

### DIFF
--- a/contrib/sarplus/scala/build.sbt
+++ b/contrib/sarplus/scala/build.sbt
@@ -16,7 +16,14 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases"),
   ),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+  libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => Nil
+    case _ => Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+  }),
+  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => Seq("-Ymacro-annotations")
+    case _ => Nil
+  }),
   sparkVer := sys.env.getOrElse("SPARK_VERSION", "3.2.1"),
   hadoopVer := sys.env.getOrElse("HADOOP_VERSION", "3.3.1"),
   libraryDependencies ++= Seq(


### PR DESCRIPTION
### Description

#### Problem                                                                               
            
  The `python` CI job detects the Scala version from the installed PySpark  and builds with `sbt ++{SCALA_VERSION}!`. PySpark 4.1.1 ships with Scala 2.13.17, which caused the build to fail because the `scalamacros paradise` compiler plugin does not exist for Scala 2.13+.                                          
                                                                                           
  #### Root Cause                                                                            
                                                                                           
  `org.scalamacros:paradise` only supports Scala 2.12.x. In Scala 2.13+, macro annotations were merged into the compiler and are enabled via the `-Ymacro-annotations` flag instead.                                    
                                                                                           
  #### Fix                     
                                                                                           
  Make the paradise plugin conditional on the Scala version:
  - Scala 2.12.x: use `paradise` plugin as before                                          
  - Scala 2.13+: use `-Ymacro-annotations` compiler flag

### Related Issues

### References


### Checklist:

- [ ] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.
