### PR TITLE
fix: reorder negative_feedback_sampler_column

### DIFF
--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -351,9 +351,10 @@ def negative_feedback_sampler(
                 col_label: neg_value,
             }
         )
-        return pd.concat(
+        combined = pd.concat(
             [user_df.assign(**{col_user: user_df.name}), new_df], ignore_index=True
         )
+        return combined[[col_user, col_item, col_label]]
 
     res_df = df.copy()
     res_df[col_label] = pos_value


### PR DESCRIPTION
### Description

#### Summary

`negative_feedback_sampler` in `recommenders/datasets/pandas_df_utils.py` returns a DataFrame with columns in the wrong order (`[itemID, feedback, userID]`) instead of the expected order (`[userID, itemID, feedback]`). This causes test failures when comparing `.values` arrays.

#### Steps to Reproduce

```python
import pandas as pd
from recommenders.datasets.pandas_df_utils import negative_feedback_sampler

df = pd.DataFrame({
    "userID": [1, 2, 3],
    "itemID": [1, 2, 3],
    "rating": [5, 5, 5],
})

result = negative_feedback_sampler(
    df,
    col_user="userID",
    col_item="itemID",
    col_label="rating",
    ratio_neg_per_user=2,
)

print(result.columns.tolist())
# Expected: ['userID', 'itemID', 'feedback']
# Actual:   ['itemID', 'feedback', 'userID']
```

#### Root Cause

The issue originates in the inner `sample_items` function used with `groupby(...).apply(...)`.

When `include_groups=False` is passed to `groupby.apply`, the group key column (`userID`) is **excluded** from `user_df`. It is then re-added via `user_df.assign(**{col_user: user_df.name})`, which appends it as the **last column**.
After `pd.concat`, the resulting column order is determined by the first DataFrame passed:
```
user_df (positive rows):  [itemID, rating, userID]   ← userID appended last
new_df  (negative rows):  [userID, itemID, rating]
```
`pd.concat` preserves the first DataFrame's column order, so the merged result has columns `[itemID, rating, userID]`. After the final `.rename(rating → feedback)`, this becomes `[itemID, feedback, userID]` — not the expected `[userID, itemID, feedback]`.

#### Failing Test

```sh
pytest tests/unit/recommenders/datasets/test_pandas_df_utils.py::test_negative_feedback_sampler

AssertionError: assert np.False_
  sample_df row: [3, 1, 3]   → (itemID=3, feedback=1, userID=3)
  res_df    row: [3, 3, 1]   → (userID=3, itemID=3, feedback=1)
```

#### Fix

In `sample_items`, explicitly reorder columns before returning:

```python
# Before
return pd.concat(
    [user_df.assign(**{col_user: user_df.name}), new_df], ignore_index=True
)

# After
combined = pd.concat(
    [user_df.assign(**{col_user: user_df.name}), new_df], ignore_index=True
)
return combined[[col_user, col_item, col_label]]
```

**File:** `recommenders/datasets/pandas_df_utils.py`, line 354


### Related Issues

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/recommenders-team/recommenders/issues/2294

### References

<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
