### PR TITLE
fix: add backward compatibility for include_groups in groupby.apply

### DIFF
--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -331,10 +331,6 @@ def negative_feedback_sampler(
     rng = np.random.default_rng(seed=seed)
 
     def sample_items(user_df):
-        # Save group key before dropping the groupby column (drop returns a new DataFrame
-        # without the .name attribute set by GroupBy)
-        user_id = user_df.name
-        user_df = user_df.drop(columns=[col_user])
         # Sample negative items for the data frame restricted to a specific user
         n_u = len(user_df)
         neg_sample_size = (
@@ -350,13 +346,13 @@ def negative_feedback_sampler(
         new_items = np.setdiff1d(items_sample, user_df[col_item])[:neg_sample_size]
         new_df = pd.DataFrame(
             data={
-                col_user: user_id,
+                col_user: user_df.name,
                 col_item: new_items,
                 col_label: neg_value,
             }
         )
         combined = pd.concat(
-            [user_df.assign(**{col_user: user_id}), new_df], ignore_index=True
+            [user_df.assign(**{col_user: user_df.name}), new_df], ignore_index=True
         )
         return combined[[col_user, col_item, col_label]]
 
@@ -364,7 +360,7 @@ def negative_feedback_sampler(
     res_df[col_label] = pos_value
 
     return (
-        res_df.groupby(col_user)
+        res_df.groupby(col_user)[[col_item, col_label]]
         .apply(sample_items)
         .reset_index(drop=True)
         .rename(columns={col_label: col_feedback})

--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -331,6 +331,10 @@ def negative_feedback_sampler(
     rng = np.random.default_rng(seed=seed)
 
     def sample_items(user_df):
+        # Save group key before dropping the groupby column (drop returns a new DataFrame
+        # without the .name attribute set by GroupBy)
+        user_id = user_df.name
+        user_df = user_df.drop(columns=[col_user])
         # Sample negative items for the data frame restricted to a specific user
         n_u = len(user_df)
         neg_sample_size = (
@@ -346,23 +350,22 @@ def negative_feedback_sampler(
         new_items = np.setdiff1d(items_sample, user_df[col_item])[:neg_sample_size]
         new_df = pd.DataFrame(
             data={
-                col_user: user_df.name,
+                col_user: user_id,
                 col_item: new_items,
                 col_label: neg_value,
             }
         )
         combined = pd.concat(
-            [user_df.assign(**{col_user: user_df.name}), new_df], ignore_index=True
+            [user_df.assign(**{col_user: user_id}), new_df], ignore_index=True
         )
         return combined[[col_user, col_item, col_label]]
 
     res_df = df.copy()
     res_df[col_label] = pos_value
-    apply_kwargs = {"include_groups": False} if pd.__version__ >= "2.2.0" else {}
 
     return (
         res_df.groupby(col_user)
-        .apply(sample_items, **apply_kwargs)
+        .apply(sample_items)
         .reset_index(drop=True)
         .rename(columns={col_label: col_feedback})
     )

--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -358,9 +358,11 @@ def negative_feedback_sampler(
 
     res_df = df.copy()
     res_df[col_label] = pos_value
+    apply_kwargs = {"include_groups": False} if pd.__version__ >= "2.2.0" else {}
+
     return (
         res_df.groupby(col_user)
-        .apply(sample_items, include_groups=False)
+        .apply(sample_items, **apply_kwargs)
         .reset_index(drop=True)
         .rename(columns={col_label: col_feedback})
     )


### PR DESCRIPTION
### Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
fix: add backward compatibility for include_groups in groupby.apply

- guard include_groups for pandas<2.0
- drop group keys to mimic include_groups=False
- prevent runtime errors in legacy environments

### Related Issues

<!--- If it fixes an open issue, please link to the issue here. -->

### References

<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
