### PR TITLE
Reduce memory footprint of Criteo data set

### DIFF
--- a/recommenders/datasets/criteo.py
+++ b/recommenders/datasets/criteo.py
@@ -1,7 +1,7 @@
 # Copyright (c) Recommenders contributors.
 # Licensed under the MIT License.
 
-
+import numpy as np
 import pandas as pd
 import os
 import tarfile
@@ -24,7 +24,12 @@ DEFAULT_HEADER = (
     + ["int{0:02d}".format(i) for i in range(13)]
     + ["cat{0:02d}".format(i) for i in range(26)]
 )
-
+CRITEO_DTYPES = (
+    [np.int8]
+    + [pd.UInt16Dtype(), pd.Int32Dtype(), pd.UInt16Dtype(), pd.UInt16Dtype(), pd.Int32Dtype(), pd.Int32Dtype(), pd.UInt16Dtype(), pd.UInt16Dtype(), pd.UInt16Dtype()]
+    + [pd.UInt8Dtype(), pd.UInt8Dtype(), pd.UInt16Dtype(), pd.UInt16Dtype()]
+    + [pd.StringDtype(storage="pyarrow")] * 26
+)           # Specify dtypes to reduce memory usage.
 
 def load_pandas_df(size="sample", local_cache_path=None, header=DEFAULT_HEADER):
     """Loads the Criteo DAC dataset as `pandas.DataFrame`. This function download, untar, and load the dataset.
@@ -57,7 +62,7 @@ def load_pandas_df(size="sample", local_cache_path=None, header=DEFAULT_HEADER):
     with download_path(local_cache_path) as path:
         filepath = download_criteo(size, path)
         filepath = extract_criteo(size, filepath)
-        df = pd.read_csv(filepath, sep="\t", header=None, names=header)
+        df = pd.read_csv(filepath, sep="\t", header=None, names=header, dtype={i: CRITEO_DTYPES[i] for i in range(40)})
     return df
 
 

--- a/tests/data_validation/recommenders/datasets/test_criteo.py
+++ b/tests/data_validation/recommenders/datasets/test_criteo.py
@@ -26,14 +26,14 @@ def test_criteo_load_pandas_df_sample(criteo_first_row):
     df = criteo.load_pandas_df(size="sample")
     assert df.shape[0] == 100000
     assert df.shape[1] == 40
-    assert df.loc[0].equals(pd.Series(criteo_first_row))
+    assert df.loc[0].replace(pd.NA, None).equals(pd.Series(criteo_first_row))
 
 
 def test_criteo_load_pandas_df_full(criteo_first_row):
     df = criteo.load_pandas_df(size="full")
     assert df.shape[0] == 45840617
     assert df.shape[1] == 40
-    assert df.loc[0].equals(pd.Series(criteo_first_row))
+    assert df.loc[0].replace(pd.NA, None).equals(pd.Series(criteo_first_row))
     del df
     gc.collect()
 

--- a/tests/responsible_ai/recommenders/datasets/test_criteo_privacy.py
+++ b/tests/responsible_ai/recommenders/datasets/test_criteo_privacy.py
@@ -12,4 +12,4 @@ def test_criteo_privacy(criteo_first_row):
     data is anonymized.
     """
     df = criteo.load_pandas_df(size="sample")
-    assert df.loc[0].equals(pd.Series(criteo_first_row)) is True
+    assert df.loc[0].replace(pd.NA, None).equals(pd.Series(criteo_first_row)) is True


### PR DESCRIPTION
### Description

Loading the full Criteo data set onto a Pandas data frame costs too much memory. This PR reduces the memory required by using data types of smaller size. 
 
### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
