### PR TITLE
fix: add pyarrow library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     "numba>=0.57.0,<1",
     "numpy<2.0.0",  # See https://github.com/recommenders-team/recommenders/issues/2224
     "pandas>2.0.0,<3.0.0",  # requires numpy
+    "pyarrow>=10.0.1",
     "retrying>=1.3.4,<2",
     "scikit-learn>=1.2.0,<2",  # requires scipy, and introduce breaking change affects feature_extraction.text.TfidfVectorizer.min_df
     "seaborn>=0.13.0,<1",  # requires matplotlib, packaging


### PR DESCRIPTION
### Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Added pyarrow>=10.0.1 to install_requires in setup.py, since criteo.py now depends on it at import time via `pd.StringDtype(storage="pyarrow")`. Previously it was only listed under spark extras, which caused ImportError in non-Spark environments (e.g., CI with [dev] extras on Python 3.9).

### Related Issues

<!--- If it fixes an open issue, please link to the issue here. -->
TODO: Update to CUDA 12 after TF → PyTorch migration is complete (#2073)
### References

<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
