### PR TITLE
Detect and re-download corrupt zip files in maybe_download

### DIFF
--- a/recommenders/datasets/download_utils.py
+++ b/recommenders/datasets/download_utils.py
@@ -32,6 +32,12 @@ def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
         filename = url.split("/")[-1]
     os.makedirs(work_directory, exist_ok=True)
     filepath = os.path.join(work_directory, filename)
+    if os.path.exists(filepath):
+        if filepath.endswith(".zip") and not is_valid_zip(filepath):
+            log.warning(f"File {filepath} is corrupt, re-downloading")
+            os.remove(filepath)
+        else:
+            log.info(f"File {filepath} already downloaded")
     if not os.path.exists(filepath):
         r = requests.get(url, stream=True)
         if r.status_code == 200:
@@ -50,8 +56,6 @@ def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
         else:
             log.error(f"Problem downloading {url}")
             r.raise_for_status()
-    else:
-        log.info(f"File {filepath} already downloaded")
     if expected_bytes is not None:
         statinfo = os.stat(filepath)
         if statinfo.st_size != expected_bytes:
@@ -59,6 +63,23 @@ def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
             raise IOError(f"Failed to verify {filepath}")
 
     return filepath
+
+
+def is_valid_zip(filepath):
+    """Check if a file is a valid zip file.
+
+    Args:
+        filepath (str): Path to the file to check.
+
+    Returns:
+        bool: True if the file is a valid zip file, False otherwise.
+    """
+    try:
+        with zipfile.ZipFile(filepath, "r") as z:
+            z.testzip()
+        return True
+    except (zipfile.BadZipFile, OSError):
+        return False
 
 
 @contextmanager

--- a/tests/unit/recommenders/datasets/test_download_utils.py
+++ b/tests/unit/recommenders/datasets/test_download_utils.py
@@ -2,12 +2,17 @@
 # Licensed under the MIT License.
 
 import os
+import zipfile
 import pytest
 import requests
 import logging
 from tempfile import TemporaryDirectory
 
-from recommenders.datasets.download_utils import maybe_download, download_path
+from recommenders.datasets.download_utils import (
+    maybe_download,
+    download_path,
+    is_valid_zip,
+)
 
 
 @pytest.fixture
@@ -64,6 +69,35 @@ def test_maybe_download_retry(caplog):
             "https://raw.githubusercontent.com/recommenders-team/resources/main/non_existing_file.zip"
         )
         assert "Problem downloading" in caplog.text
+
+
+def test_is_valid_zip(tmp):
+    valid_zip = os.path.join(tmp, "valid.zip")
+    with zipfile.ZipFile(valid_zip, "w") as zf:
+        zf.writestr("test.txt", "hello")
+    assert is_valid_zip(valid_zip) is True
+
+    corrupt_zip = os.path.join(tmp, "corrupt.zip")
+    with open(corrupt_zip, "wb") as f:
+        f.write(b"this is not a zip file")
+    assert is_valid_zip(corrupt_zip) is False
+
+
+def test_maybe_download_redownloads_corrupt_zip(tmp, caplog):
+    caplog.clear()
+    caplog.set_level(logging.WARNING)
+    corrupt_zip = os.path.join(tmp, "ml-100k.zip")
+    with open(corrupt_zip, "wb") as f:
+        f.write(b"truncated content")
+    assert os.path.exists(corrupt_zip)
+
+    url = (
+        "https://raw.githubusercontent.com/recommenders-team/recommenders/main/LICENSE"
+    )
+    downloaded = maybe_download(url, "ml-100k.zip", work_directory=tmp)
+    assert "corrupt, re-downloading" in caplog.text
+    assert os.path.exists(downloaded)
+    assert os.path.getsize(downloaded) > 17
 
 
 def test_download_path():


### PR DESCRIPTION
A partial download that gets interrupted leaves a truncated zip file on disk. On retry, maybe_download sees the file exists and skips the download, causing BadZipFile errors that persist across all retries.

Add is_valid_zip() to validate existing zip files before skipping the download. If the file is corrupt, delete it and re-download.

### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [ ] This PR is being made to `staging branch` AND NOT TO `main branch`.
