### PR TITLE
[codex] fix(gpu): use imported cuda namespace for gpu counting

### DIFF
--- a/recommenders/utils/gpu_utils.py
+++ b/recommenders/utils/gpu_utils.py
@@ -27,9 +27,7 @@ def get_number_gpus():
     except (ImportError, ModuleNotFoundError):
         pass
     try:
-        import numba
-
-        return len(numba.cuda.gpus)
+        return len(cuda.gpus)
     except Exception:  # numba.cuda.cudadrv.error.CudaSupportError:
         return 0
 

--- a/tests/test_groups.yml
+++ b/tests/test_groups.yml
@@ -386,6 +386,7 @@ pr_gate:
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_sampler # FIXME: it takes too long to run
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_sasrec # FIXME: it takes too long to run
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_ssept # FIXME: it takes too long to run
+    - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_number_gpus_falls_back_to_cuda_namespace_when_torch_is_missing
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_gpu_info
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_number_gpus
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_clear_memory_all_gpus

--- a/tests/test_groups.yml
+++ b/tests/test_groups.yml
@@ -386,7 +386,7 @@ pr_gate:
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_sampler # FIXME: it takes too long to run
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_sasrec # FIXME: it takes too long to run
     # - tests/unit/recommenders/models/test_sasrec_model.py::test_ssept # FIXME: it takes too long to run
-    - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_number_gpus_falls_back_to_cuda_namespace_when_torch_is_missing
+    - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_number_gpus_without_torch
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_gpu_info
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_get_number_gpus
     - tests/unit/recommenders/utils/test_gpu_utils.py::test_clear_memory_all_gpus

--- a/tests/unit/recommenders/utils/test_gpu_utils.py
+++ b/tests/unit/recommenders/utils/test_gpu_utils.py
@@ -21,9 +21,7 @@ except ImportError:
     pass  # skip this import if we are in cpu environment
 
 
-def test_get_number_gpus_falls_back_to_cuda_namespace_when_torch_is_missing(
-    monkeypatch,
-):
+def test_get_number_gpus_without_torch(monkeypatch):
     fake_cuda = SimpleNamespace(gpus=["gpu0", "gpu1"])
     real_import = builtins.__import__
 

--- a/tests/unit/recommenders/utils/test_gpu_utils.py
+++ b/tests/unit/recommenders/utils/test_gpu_utils.py
@@ -2,8 +2,11 @@
 # Licensed under the MIT License.
 
 
+import builtins
 import sys
+from types import SimpleNamespace
 import pytest
+import recommenders.utils.gpu_utils as gpu_utils
 
 try:
     import tensorflow as tf
@@ -16,6 +19,25 @@ try:
     )
 except ImportError:
     pass  # skip this import if we are in cpu environment
+
+
+def test_get_number_gpus_falls_back_to_cuda_namespace_when_torch_is_missing(
+    monkeypatch,
+):
+    fake_cuda = SimpleNamespace(gpus=["gpu0", "gpu1"])
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ModuleNotFoundError("torch is unavailable in this test")
+        if name == "numba":
+            return SimpleNamespace()
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(gpu_utils, "cuda", fake_cuda)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert gpu_utils.get_number_gpus() == 2
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Summary
- fix `get_number_gpus()` to use the already imported `cuda` namespace instead of `numba.cuda`
- add a regression test that simulates `torch` being unavailable and a `numba` module without a `cuda` attribute
- register the new regression test in `tests/test_groups.yml` so the PR gate runs it

## Root Cause
`recommenders.utils.gpu_utils` imports `cuda` with `from numba import cuda`, but `get_number_gpus()` fell back to `numba.cuda.gpus` when `torch` was unavailable. In environments where `numba.cuda` is not exposed through the top-level `numba` module, that path raises `AttributeError: module 'numba' has no attribute 'cuda'` and incorrectly reports zero GPUs.

## Impact
When PyTorch is unavailable, GPU counting now follows the same import path already used by `get_gpu_info()` and `clear_memory_all_gpus()`. That keeps `get_number_gpus()` aligned with the rest of the module and avoids the `numba.cuda` attribute error reported in #2198.

## Validation
- `pytest tests/unit/recommenders/utils/test_gpu_utils.py -k "falls_back_to_cuda_namespace_when_torch_is_missing"`

Fixes #2198
