### PR TITLE
Fix asset URL in fm_deep_dive.ipynb

### DIFF
--- a/examples/02_model_collaborative_filtering/fm_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/fm_deep_dive.ipynb
@@ -466,7 +466,7 @@
                 "output_file = os.path.join(data_path, OUTPUT_FILE_NAME)\n",
                 "\n",
                 "assets_url = (\n",
-                "    \"https://raw.githubusercontent.com/recommenders-team/resources/mains-team/resources/mains-team/resources/mains-team/resources/mains-team/resources/mains-team/resources/mains-team/resources/main/deeprec/xdeepfmresources.zip\"\n",
+                "    \"https://raw.githubusercontent.com/recommenders-team/resources/main/deeprec/xdeepfmresources.zip\"\n",
                 ")\n",
                 "assets_file = maybe_download(assets_url, work_directory=data_path)\n",
                 "unzip_file(assets_file, data_path)\n"


### PR DESCRIPTION
path had `mains-team/resources` repeated muiltiple times

this is corrected to  value in https://github.com/recommenders-team/recommenders/blob/main/examples/00_quick_start/xdeepfm_criteo.ipynb

### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
