### PR TITLE
fix: use MAP@k in examples

### DIFF
--- a/examples/00_quick_start/embdotbias_movielens.ipynb
+++ b/examples/00_quick_start/embdotbias_movielens.ipynb
@@ -1140,7 +1140,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_map = map(test_df, top_k_scores, col_user=USER, col_item=ITEM, \n",
+    "eval_map = map_at_k(test_df, top_k_scores, col_user=USER, col_item=ITEM, \n",
     "               col_rating=RATING, col_prediction=PREDICTION, \n",
     "               relevancy_method=\"top_k\", k=TOP_K)"
    ]

--- a/examples/00_quick_start/lightgbm_movielens.ipynb
+++ b/examples/00_quick_start/lightgbm_movielens.ipynb
@@ -131,7 +131,7 @@
     "from recommenders.datasets import movielens\n",
     "from recommenders.datasets.pandas_df_utils import negative_feedback_sampler\n",
     "from recommenders.datasets.python_splitters import python_chrono_split\n",
-    "from recommenders.evaluation.python_evaluation import map, ndcg_at_k\n",
+    "from recommenders.evaluation.python_evaluation import map_at_k, ndcg_at_k\n",
     "from recommenders.models.lightgbm.lightgbm_utils import NumEncoder\n",
     "from recommenders.utils.notebook_utils import store_metadata\n",
     "\n",
@@ -1515,7 +1515,7 @@
     }
    ],
    "source": [
-    "eval_map10 = map(\n",
+    "eval_map10 = map_at_k(\n",
     "    true_df,\n",
     "    pred_df,\n",
     "    col_user=USER_COL,\n",

--- a/examples/00_quick_start/ncf_movielens.ipynb
+++ b/examples/00_quick_start/ncf_movielens.ipynb
@@ -304,7 +304,7 @@
     }
    ],
    "source": [
-    "eval_map = map(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
+    "eval_map = map_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_ndcg = ndcg_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_precision = precision_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_recall = recall_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",

--- a/examples/00_quick_start/sar_movielens.ipynb
+++ b/examples/00_quick_start/sar_movielens.ipynb
@@ -68,7 +68,7 @@
                 "from recommenders.datasets.python_splitters import python_stratified_split\n",
                 "from recommenders.models.sar import SAR\n",
                 "from recommenders.evaluation.python_evaluation import (\n",
-                "    map,\n",
+                "    map_at_k,\n",
                 "    ndcg_at_k,\n",
                 "    precision_at_k,\n",
                 "    recall_at_k,\n",
@@ -509,7 +509,7 @@
             "outputs": [],
             "source": [
                 "# Ranking metrics\n",
-                "eval_map = map(test, top_k, col_user=\"userID\", col_item=\"itemID\", col_rating=\"rating\", k=TOP_K)\n",
+                "eval_map = map_at_k(test, top_k, col_user=\"userID\", col_item=\"itemID\", col_rating=\"rating\", k=TOP_K)\n",
                 "eval_ndcg = ndcg_at_k(test, top_k, col_user=\"userID\", col_item=\"itemID\", col_rating=\"rating\", k=TOP_K)\n",
                 "eval_precision = precision_at_k(test, top_k, col_user=\"userID\", col_item=\"itemID\", col_rating=\"rating\", k=TOP_K)\n",
                 "eval_recall = recall_at_k(test, top_k, col_user=\"userID\", col_item=\"itemID\", col_rating=\"rating\", k=TOP_K)\n"

--- a/examples/02_model_collaborative_filtering/baseline_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/baseline_deep_dive.ipynb
@@ -78,7 +78,7 @@
                 "    mae,\n",
                 "    rsquared,\n",
                 "    exp_var,\n",
-                "    map,\n",
+                "    map_at_k,\n",
                 "    ndcg_at_k,\n",
                 "    precision_at_k,\n",
                 "    recall_at_k,\n",
@@ -689,7 +689,7 @@
             "source": [
                 "cols[\"col_prediction\"] = \"Count\"\n",
                 "\n",
-                "eval_map = map(test, baseline_recommendations, k=TOP_K, **cols)\n",
+                "eval_map = map_at_k(test, baseline_recommendations, k=TOP_K, **cols)\n",
                 "eval_ndcg = ndcg_at_k(test, baseline_recommendations, k=TOP_K, **cols)\n",
                 "eval_precision = precision_at_k(test, baseline_recommendations, k=TOP_K, **cols)\n",
                 "eval_recall = recall_at_k(test, baseline_recommendations, k=TOP_K, **cols)\n",

--- a/examples/02_model_collaborative_filtering/cornac_bivae_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/cornac_bivae_deep_dive.ipynb
@@ -55,7 +55,7 @@
                 "from recommenders.utils.timer import Timer\n",
                 "from recommenders.utils.constants import SEED\n",
                 "from recommenders.evaluation.python_evaluation import (\n",
-                "    map,\n",
+                "    map_at_k,\n",
                 "    ndcg_at_k,\n",
                 "    precision_at_k,\n",
                 "    recall_at_k,\n",
@@ -507,7 +507,7 @@
                 }
             ],
             "source": [
-                "eval_map = map(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
+                "eval_map = map_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_ndcg = ndcg_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_precision = precision_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_recall = recall_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",

--- a/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb
@@ -47,7 +47,7 @@
                 "\n",
                 "from recommenders.datasets import movielens\n",
                 "from recommenders.datasets.python_splitters import python_random_split\n",
-                "from recommenders.evaluation.python_evaluation import map, ndcg_at_k, precision_at_k, recall_at_k\n",
+                "from recommenders.evaluation.python_evaluation import map_at_k, ndcg_at_k, precision_at_k, recall_at_k\n",
                 "from recommenders.models.cornac.bpr import BPR\n",
                 "from recommenders.utils.timer import Timer\n",
                 "from recommenders.utils.constants import SEED\n",
@@ -563,7 +563,7 @@
                 }
             ],
             "source": [
-                "eval_map = map(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
+                "eval_map = map_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_ndcg = ndcg_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_precision = precision_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
                 "eval_recall = recall_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",

--- a/examples/02_model_collaborative_filtering/lightgcn_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/lightgcn_deep_dive.ipynb
@@ -62,7 +62,7 @@
                 "from recommenders.models.deeprec.DataModel.ImplicitCF import ImplicitCF\n",
                 "from recommenders.datasets import movielens\n",
                 "from recommenders.datasets.python_splitters import python_stratified_split\n",
-                "from recommenders.evaluation.python_evaluation import map, ndcg_at_k, precision_at_k, recall_at_k\n",
+                "from recommenders.evaluation.python_evaluation import map_at_k, ndcg_at_k, precision_at_k, recall_at_k\n",
                 "from recommenders.utils.constants import SEED as DEFAULT_SEED\n",
                 "from recommenders.models.deeprec.deeprec_utils import prepare_hparams\n",
                 "from recommenders.utils.notebook_utils import store_metadata\n",
@@ -640,7 +640,7 @@
                 }
             ],
             "source": [
-                "eval_map = map(test, topk_scores, k=TOP_K)\n",
+                "eval_map = map_at_k(test, topk_scores, k=TOP_K)\n",
                 "eval_ndcg = ndcg_at_k(test, topk_scores, k=TOP_K)\n",
                 "eval_precision = precision_at_k(test, topk_scores, k=TOP_K)\n",
                 "eval_recall = recall_at_k(test, topk_scores, k=TOP_K)\n",

--- a/examples/02_model_collaborative_filtering/ncf_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/ncf_deep_dive.ipynb
@@ -552,7 +552,7 @@
     }
    ],
    "source": [
-    "eval_map = map(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
+    "eval_map = map_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_ndcg = ndcg_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_precision = precision_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_recall = recall_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
@@ -830,7 +830,7 @@
     }
    ],
    "source": [
-    "eval_map2 = map(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
+    "eval_map2 = map_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_ndcg2 = ndcg_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_precision2 = precision_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",
     "eval_recall2 = recall_at_k(test, all_predictions, col_prediction='prediction', k=TOP_K)\n",

--- a/examples/06_benchmarks/benchmark_utils.py
+++ b/examples/06_benchmarks/benchmark_utils.py
@@ -15,7 +15,7 @@ except ImportError:
     pass  # skip this import if we are not in a Spark environment
 try:
     import surprise  # Put SVD surprise back in core deps when #2224 is fixed
-except:
+except ImportError:
     pass
 
 from recommenders.utils.timer import Timer
@@ -37,7 +37,7 @@ from recommenders.models.surprise.surprise_utils import (
     compute_ranking_predictions,
 )
 from recommenders.evaluation.python_evaluation import (
-    map,
+    map_at_k,
     ndcg_at_k,
     precision_at_k,
     recall_at_k,
@@ -415,7 +415,7 @@ def ranking_metrics_pyspark(test, predictions, k=DEFAULT_K):
         test, predictions, k=k, relevancy_method="top_k", **COL_DICT
     )
     return {
-        "MAP": rank_eval.map(),
+        "MAP": rank_eval.map_at_k(),
         "nDCG@k": rank_eval.ndcg_at_k(),
         "Precision@k": rank_eval.precision_at_k(),
         "Recall@k": rank_eval.recall_at_k(),
@@ -433,7 +433,7 @@ def rating_metrics_python(test, predictions):
 
 def ranking_metrics_python(test, predictions, k=DEFAULT_K):
     return {
-        "MAP": map(test, predictions, k=k, **COL_DICT),
+        "MAP": map_at_k(test, predictions, k=k, **COL_DICT),
         "nDCG@k": ndcg_at_k(test, predictions, k=k, **COL_DICT),
         "Precision@k": precision_at_k(test, predictions, k=k, **COL_DICT),
         "Recall@k": recall_at_k(test, predictions, k=k, **COL_DICT),

--- a/recommenders/evaluation/python_evaluation.py
+++ b/recommenders/evaluation/python_evaluation.py
@@ -759,7 +759,7 @@ def map(
     threshold=DEFAULT_THRESHOLD,
     **_,
 ):
-    """Mean Average Precision for top k prediction items
+    """Mean Average Precision for ranked prediction items
 
     The implementation of MAP is referenced from Spark MLlib evaluation metrics.
     https://spark.apache.org/docs/2.3.0/mllib-evaluation-metrics.html#ranking-systems
@@ -770,6 +770,8 @@ def map(
     Note:
         The MAP is meant to calculate Avg. Precision for the relevant items, so it is normalized by the number of
         relevant items in the ground truth data, instead of k.
+        Use ``map_at_k`` when the metric should be normalized by
+        ``min(number of relevant items, k)``.
 
     Args:
         rating_true (pandas.DataFrame): True DataFrame


### PR DESCRIPTION
## Description

Fixes #2309.

The benchmark helper and affected example notebooks were reporting MAP@k-style metrics while calling the plain MAP implementation. This switches those call sites to map_at_k and tightens the map() docstring so the two metrics are easier to distinguish.

I also changed the import guard in benchmark_utils.py from a bare except to ImportError while touching that import block.

## Testing

- python -m py_compile examples\06_benchmarks\benchmark_utils.py recommenders\evaluation\python_evaluation.py
- python -m pytest tests\unit\recommenders\evaluation\test_python_evaluation.py::test_python_map_at_k tests\unit\recommenders\evaluation\test_python_evaluation.py::test_python_map -q
- python -m ruff check examples\06_benchmarks\benchmark_utils.py recommenders\evaluation\python_evaluation.py
- python -m flake8 --select=E722 examples\06_benchmarks\benchmark_utils.py recommenders\evaluation\python_evaluation.py
- JSON parse check for the touched notebooks
- git diff --check

Note: full flake8 on these two files still reports historical line-length and spacing issues unrelated to this patch.
