### PR TITLE
fix: replace LightGCN np.mat usage

### DIFF
--- a/recommenders/models/deeprec/models/graphrec/lightgcn.py
+++ b/recommenders/models/deeprec/models/graphrec/lightgcn.py
@@ -202,7 +202,7 @@ class LightGCN(object):
 
         """
         coo = X.tocoo().astype(np.float32)
-        indices = np.mat([coo.row, coo.col]).transpose()
+        indices = np.asmatrix([coo.row, coo.col]).transpose()
         return tf.SparseTensor(indices, coo.data, coo.shape)
 
     def fit(self):


### PR DESCRIPTION
Fixes #2326.

`np.mat` was removed in NumPy 2.0. LightGCN only needs to build a matrix-shaped index array before creating the TensorFlow sparse tensor, so `np.asmatrix` keeps the same behavior without depending on the removed alias.

Validation:
- `python -c "import numpy as np, scipy.sparse as sp; coo=sp.coo_matrix(([1.0], ([0], [1])), shape=(2,2)); indices=np.asmatrix([coo.row, coo.col]).transpose(); print(np.__version__, hasattr(np, 'mat'), indices.tolist())"`
- `python -m py_compile recommenders\models\deeprec\models\graphrec\lightgcn.py`
- `python -m ruff check recommenders\models\deeprec\models\graphrec\lightgcn.py`
- `git diff --check`

I also tried the existing targeted LightGCN unit test:

`python -m pytest tests\unit\recommenders\models\test_deeprec_model.py::test_lightgcn_component_definition -q`

That test did not reach LightGCN on this Windows Python 3.13 environment because the local environment is missing the older deeprec dependency chain (`retrying` first, then TensorFlow; the repo pins TensorFlow `<2.16`, which is not compatible with Python 3.13). The NumPy compatibility check above ran with NumPy 2.3.4 and confirmed `np.mat` is absent.
