### PR TITLE
fix: set default timeout for dataset downloads

### DIFF
--- a/recommenders/datasets/download_utils.py
+++ b/recommenders/datasets/download_utils.py
@@ -11,12 +11,19 @@ from tempfile import TemporaryDirectory
 from tqdm import tqdm
 from retrying import retry
 
-
 log = logging.getLogger(__name__)
+
+DEFAULT_DOWNLOAD_TIMEOUT = (10, 60)
 
 
 @retry(wait_random_min=1000, wait_random_max=5000, stop_max_attempt_number=5)
-def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
+def maybe_download(
+    url,
+    filename=None,
+    work_directory=".",
+    expected_bytes=None,
+    timeout=DEFAULT_DOWNLOAD_TIMEOUT,
+):
     """Download a file if it is not already downloaded.
 
     Args:
@@ -24,6 +31,7 @@ def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
         work_directory (str): Working directory.
         url (str): URL of the file to download.
         expected_bytes (int): Expected file size in bytes.
+        timeout (float|tuple): Requests timeout for the download.
 
     Returns:
         str: File path of the file downloaded.
@@ -39,7 +47,7 @@ def maybe_download(url, filename=None, work_directory=".", expected_bytes=None):
         else:
             log.info(f"File {filepath} already downloaded")
     if not os.path.exists(filepath):
-        r = requests.get(url, stream=True)
+        r = requests.get(url, stream=True, timeout=timeout)
         if r.status_code == 200:
             log.info(f"Downloading {url}")
             total_size = int(r.headers.get("content-length", 0))

--- a/tests/unit/recommenders/datasets/test_download_utils.py
+++ b/tests/unit/recommenders/datasets/test_download_utils.py
@@ -71,6 +71,32 @@ def test_maybe_download_retry(caplog):
         assert "Problem downloading" in caplog.text
 
 
+def test_maybe_download_sets_default_timeout(tmp_path, monkeypatch):
+    captured = {}
+
+    class Response:
+        status_code = 200
+        headers = {"content-length": "4"}
+
+        def iter_content(self, block_size):
+            yield b"done"
+
+    def mock_get(url, stream, timeout):
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("recommenders.datasets.download_utils.requests.get", mock_get)
+
+    downloaded = maybe_download(
+        "https://example.com/file.txt",
+        "file.txt",
+        work_directory=tmp_path,
+    )
+
+    assert captured["timeout"] == (10, 60)
+    assert os.path.exists(downloaded)
+
+
 def test_is_valid_zip(tmp):
     valid_zip = os.path.join(tmp, "valid.zip")
     with zipfile.ZipFile(valid_zip, "w") as zf:


### PR DESCRIPTION
## Summary
- Add a finite default timeout for dataset downloads
- Keep the existing retry wrapper so transient connection failures still get another attempt
- Cover the timeout wiring in the download utility unit tests

Fixes #2331

Co-authored by @he-yufeng (original PR #2332, rebased onto staging to resolve conflicts)

## To verify
- python -m pytest tests/unit/recommenders/datasets/test_download_utils.py -q -p no:cacheprovider --basetemp .tmp/pytest
- python -m black --check recommenders/datasets/download_utils.py tests/unit/recommenders/datasets/test_download_utils.py
- python -m py_compile recommenders/datasets/download_utils.py tests/unit/recommenders/datasets/test_download_utils.py
- git diff --check