### PR TITLE
fix: query GPU memory with torch first

### DIFF
--- a/recommenders/utils/gpu_utils.py
+++ b/recommenders/utils/gpu_utils.py
@@ -8,7 +8,6 @@ import logging
 from numba import cuda
 from numba.cuda.cudadrv.error import CudaSupportError
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -41,6 +40,23 @@ def get_gpu_info():
     """
     gpus = []
     try:
+        import torch
+
+        if torch.cuda.is_available():
+            for device_id in range(torch.cuda.device_count()):
+                free_memory, total_memory = torch.cuda.mem_get_info(device_id)
+                gpus.append(
+                    {
+                        "device_name": torch.cuda.get_device_name(device_id),
+                        "total_memory": total_memory / 1048576,  # Mb
+                        "free_memory": free_memory / 1048576,  # Mb
+                    }
+                )
+            return gpus
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    try:
         for gpu in cuda.gpus:
             with gpu:
                 meminfo = cuda.current_context().get_memory_info()
@@ -50,7 +66,7 @@ def get_gpu_info():
                     "free_memory": meminfo[0] / 1048576,  # Mb
                 }
                 gpus.append(g)
-    except CudaSupportError:
+    except Exception:
         pass
 
     return gpus

--- a/tests/unit/recommenders/utils/test_gpu_utils.py
+++ b/tests/unit/recommenders/utils/test_gpu_utils.py
@@ -38,6 +38,50 @@ def test_get_number_gpus_without_torch(monkeypatch):
     assert gpu_utils.get_number_gpus() == 2
 
 
+def test_get_gpu_info_uses_torch_cuda(monkeypatch):
+    class FakeCuda:
+        @staticmethod
+        def is_available():
+            return True
+
+        @staticmethod
+        def device_count():
+            return 1
+
+        @staticmethod
+        def mem_get_info(device):
+            assert device == 0
+            return 256 * 1048576, 1024 * 1048576
+
+        @staticmethod
+        def get_device_name(device):
+            assert device == 0
+            return "Test GPU"
+
+    class BrokenNumbaGpu:
+        def __enter__(self):
+            raise AssertionError("numba should not be used when torch has CUDA")
+
+    fake_torch = SimpleNamespace(cuda=FakeCuda)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            return fake_torch
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(gpu_utils, "cuda", SimpleNamespace(gpus=[BrokenNumbaGpu()]))
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert gpu_utils.get_gpu_info() == [
+        {
+            "device_name": "Test GPU",
+            "total_memory": 1024,
+            "free_memory": 256,
+        }
+    ]
+
+
 @pytest.mark.gpu
 def test_get_gpu_info():
     assert len(get_gpu_info()) >= 1


### PR DESCRIPTION
﻿## Summary
- use PyTorch's CUDA API first when collecting GPU memory info
- keep the existing numba path as a fallback when torch is unavailable
- tolerate numba CUDA context errors so `get_gpu_info()` returns an empty list instead of failing

## To verify
- `uv run --python 3.11 --with pytest --with numba --with pandas --with scikit-learn python -m pytest tests\unit\recommenders\utils\test_gpu_utils.py::test_get_gpu_info_uses_torch_cuda tests\unit\recommenders\utils\test_gpu_utils.py::test_get_number_gpus_without_torch -q --basetemp .tmp\pytest`
- `uv run --python 3.11 --with black black --check recommenders\utils\gpu_utils.py tests\unit\recommenders\utils\test_gpu_utils.py`
- `uv run --python 3.11 --with numba --with pandas --with scikit-learn python -m py_compile recommenders\utils\gpu_utils.py tests\unit\recommenders\utils\test_gpu_utils.py`
- `git diff --check`

I did not run GPU-marked tests locally because this machine does not have the required GPU test environment.

Fixes #2344
