### PR TITLE
Cancel in-progress workflow run when new commits come in

### DIFF
--- a/.github/workflows/cpu-nightly.yml
+++ b/.github/workflows/cpu-nightly.yml
@@ -38,6 +38,10 @@ on:
         description: 'Tags to label this manual run (optional)'
         default: 'Manual trigger'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     uses: ./.github/workflows/compshare-vm.yml

--- a/.github/workflows/gpu-nightly.yml
+++ b/.github/workflows/gpu-nightly.yml
@@ -38,6 +38,10 @@ on:
         description: 'Tags to label this manual run (optional)'
         default: 'Manual trigger'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     uses: ./.github/workflows/compshare-vm.yml

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -26,6 +26,10 @@ on:
   # Enable manual trigger
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   SARPLUS_ROOT: ${{ github.workspace }}/contrib/sarplus
   PYTHON_ROOT: ${{ github.workspace }}/contrib/sarplus/python

--- a/.github/workflows/spark-nightly.yml
+++ b/.github/workflows/spark-nightly.yml
@@ -38,6 +38,10 @@ on:
         description: 'Tags to label this manual run (optional)'
         default: 'Manual trigger'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     uses: ./.github/workflows/compshare-vm.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,10 @@ on:
         description: 'Tags to label this manual run (optional)'
         default: 'Manual trigger'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     uses: ./.github/workflows/compshare-vm.yml

--- a/.github/workflows/update_documentation.yml
+++ b/.github/workflows/update_documentation.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
When a PR is created, subsequent commits may trigger multiple corresponding workflow runs if previous runs are still in progress.  This PR uses [concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) to cancel those in-progress out-of-date runs.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
