### PR TITLE
docs: label MAP@k notebook outputs consistently

### DIFF
--- a/examples/00_quick_start/als_movielens.ipynb
+++ b/examples/00_quick_start/als_movielens.ipynb
@@ -416,7 +416,7 @@
                     "text": [
                         "Model:\tALS\n",
                         "Top K:\t10\n",
-                        "MAP:\t0.006527\n",
+                        "MAP@K:\t0.006527\n",
                         "NDCG:\t0.051718\n",
                         "Precision@K:\t0.051274\n",
                         "Recall@K:\t0.018840\n"
@@ -434,7 +434,7 @@
             "source": [
                 "print(\"Model:\\tALS\",\n",
                 "      \"Top K:\\t%d\" % rank_eval.k,\n",
-                "      \"MAP:\\t%f\" % rank_eval.map_at_k(),\n",
+                "      \"MAP@K:\\t%f\" % rank_eval.map_at_k(),\n",
                 "      \"NDCG:\\t%f\" % rank_eval.ndcg_at_k(),\n",
                 "      \"Precision@K:\\t%f\" % rank_eval.precision_at_k(),\n",
                 "      \"Recall@K:\\t%f\" % rank_eval.recall_at_k(), sep='\\n')"

--- a/examples/02_model_collaborative_filtering/als_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/als_deep_dive.ipynb
@@ -502,7 +502,7 @@
                         "Precision@k = 0.04379639448568401\n",
                         "Recall@k = 0.014286194686756822\n",
                         "NDCG@k = 0.03730295615527768\n",
-                        "Mean average precision = 0.0034619726118607337\n"
+                        "MAP@k = 0.0034619726118607337\n"
                     ]
                 },
                 {
@@ -529,7 +529,7 @@
                 "    \"Precision@k = {}\".format(evaluations.precision_at_k()),\n",
                 "    \"Recall@k = {}\".format(evaluations.recall_at_k()),\n",
                 "    \"NDCG@k = {}\".format(evaluations.ndcg_at_k()),\n",
-                "    \"Mean average precision = {}\".format(evaluations.map_at_k()),\n",
+                "    \"MAP@k = {}\".format(evaluations.map_at_k()),\n",
                 "    sep=\"\\n\"\n",
                 ")"
             ]

--- a/examples/02_model_collaborative_filtering/surprise_svd_deep_dive.ipynb
+++ b/examples/02_model_collaborative_filtering/surprise_svd_deep_dive.ipynb
@@ -587,7 +587,7 @@
                 "\n",
                 "As we can see, the RMSE and MAE (Mean Absolute Error) are pretty low (i.e. good), indicating that on average the error in the predicted ratings is less than 1. The RMSE is of course a bit higher, because high errors are penalized much more.\n",
                 "\n",
-                "For comparison with other models, we also display Top-k and ranking metrics (MAP, NDCG, etc.). Note however that the SVD algorithm was designed for achieving high accuracy, not for top-rank predictions."
+                "For comparison with other models, we also display Top-k and ranking metrics (MAP@K, NDCG, etc.). Note however that the SVD algorithm was designed for achieving high accuracy, not for top-rank predictions."
             ]
         },
         {
@@ -604,7 +604,7 @@
                         "rsquared:\t0.288045\n",
                         "exp var:\t0.288157\n",
                         "----\n",
-                        "MAP:\t\t0.051501\n",
+                        "MAP@K:\t\t0.051501\n",
                         "NDCG:\t\t0.110465\n",
                         "Precision@K:\t0.100425\n",
                         "Recall@K:\t0.035267\n"
@@ -636,7 +636,7 @@
                 "print(\"----\")\n",
                 "\n",
                 "print(\n",
-                "    \"MAP:\\t\\t%f\" % eval_map,\n",
+                "    \"MAP@K:\\t\\t%f\" % eval_map,\n",
                 "    \"NDCG:\\t\\t%f\" % eval_ndcg,\n",
                 "    \"Precision@K:\\t%f\" % eval_precision,\n",
                 "    \"Recall@K:\\t%f\" % eval_recall,\n",

--- a/examples/03_evaluate/als_movielens_diversity_metrics.ipynb
+++ b/examples/03_evaluate/als_movielens_diversity_metrics.ipynb
@@ -38,7 +38,7 @@
                 " - We also define a process which randomly recommends unseen items to each user. \n",
                 " - We show two options to calculate item-item similarity: (1) based on item co-occurrence count; and (2) based on item feature vectors.\n",
                 " \n",
-                "The comparision results show that the ALS recommender outperforms the random recommender on ranking metrics (Precision@k, Recall@k, NDCG@k, and\tMean average precision), while the random recommender outperforms ALS recommender on diversity metrics. This is because ALS is optimized for estimating the item rating as accurate as possible, therefore it performs well on accuracy metrics including rating and ranking metrics. As a side effect, the items being recommended tend to be popular items, which are the items mostly sold or viewed. It leaves the [long-tail items](https://github.com/microsoft/recommenders/blob/main/GLOSSARY.md) having less chance to get introduced to the users. This is the reason why ALS is not performing as well as a random recommender on diversity metrics. \n",
+                "The comparision results show that the ALS recommender outperforms the random recommender on ranking metrics (Precision@k, Recall@k, NDCG@k, and\tMAP@k), while the random recommender outperforms ALS recommender on diversity metrics. This is because ALS is optimized for estimating the item rating as accurate as possible, therefore it performs well on accuracy metrics including rating and ranking metrics. As a side effect, the items being recommended tend to be popular items, which are the items mostly sold or viewed. It leaves the [long-tail items](https://github.com/microsoft/recommenders/blob/main/GLOSSARY.md) having less chance to get introduced to the users. This is the reason why ALS is not performing as well as a random recommender on diversity metrics. \n",
                 "\n",
                 "From the algorithmic point of view, items in the tail suffer from the cold-start problem, making them hard for recommendation systems to use. However, from the business point of view, oftentimes the items in the tail can be highly profitable, since, depending on supply, business can apply a higher margin to them. Recommendation systems that optimize metrics like novelty and diversity, can help to find users willing to get these long tail items. Usually there is a trade-off between one type of metric vs. another. One should decide which set of metrics to optimize based on business scenarios."
             ]
@@ -576,7 +576,7 @@
                 "        \"Precision@k\": ranking_eval.precision_at_k(),\n",
                 "        \"Recall@k\": ranking_eval.recall_at_k(),\n",
                 "        \"NDCG@k\": ranking_eval.ndcg_at_k(),\n",
-                "        \"Mean average precision\": ranking_eval.map_at_k()\n",
+                "        \"MAP@k\": ranking_eval.map_at_k()\n",
                 "      \n",
                 "    }\n",
                 "    return metrics   \n",
@@ -761,7 +761,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "cols = [\"Data\", \"Algo\", \"K\", \"Precision@k\", \"Recall@k\", \"NDCG@k\", \"Mean average precision\",\"catalog_coverage\", \"distributional_coverage\",\"novelty\", \"diversity\", \"serendipity\" ]\n",
+                "cols = [\"Data\", \"Algo\", \"K\", \"Precision@k\", \"Recall@k\", \"NDCG@k\", \"MAP@k\",\"catalog_coverage\", \"distributional_coverage\",\"novelty\", \"diversity\", \"serendipity\" ]\n",
                 "df_results = pd.DataFrame(columns=cols)\n",
                 "\n",
                 "df_results.loc[1] = als_results \n",
@@ -800,7 +800,7 @@
                             "      <th>Precision@k</th>\n",
                             "      <th>Recall@k</th>\n",
                             "      <th>NDCG@k</th>\n",
-                            "      <th>Mean average precision</th>\n",
+                            "      <th>MAP@k</th>\n",
                             "      <th>catalog_coverage</th>\n",
                             "      <th>distributional_coverage</th>\n",
                             "      <th>novelty</th>\n",
@@ -844,7 +844,7 @@
                             "</div>"
                         ],
                         "text/plain": [
-                            "   Data    Algo   K  Precision@k  Recall@k    NDCG@k  Mean average precision  \\\n",
+                            "   Data    Algo   K  Precision@k  Recall@k    NDCG@k    MAP@k  \\\n",
                             "1  100k     als  10     0.044374  0.015567  0.040657                0.004202   \n",
                             "2  100k  random  10     0.018259  0.006516  0.018537                0.002038   \n",
                             "\n",
@@ -871,7 +871,7 @@
             "metadata": {},
             "source": [
                 "#### Conclusion\n",
-                "The comparision results show that the ALS recommender outperforms the random recommender on ranking metrics (Precision@k, Recall@k, NDCG@k, and\tMean average precision), while the random recommender outperforms ALS recommender on diversity metrics. This is because ALS is optimized for estimating the item rating as accurate as possible, therefore it performs well on accuracy metrics including rating and ranking metrics. As a side effect, the items being recommended tend to be popular items, which are the items mostly sold or viewed. It leaves the long-tail less popular items having less chance to get introduced to the users. This is the reason why ALS is not performing as well as a random recommender on diversity metrics. "
+                "The comparision results show that the ALS recommender outperforms the random recommender on ranking metrics (Precision@k, Recall@k, NDCG@k, and\tMAP@k), while the random recommender outperforms ALS recommender on diversity metrics. This is because ALS is optimized for estimating the item rating as accurate as possible, therefore it performs well on accuracy metrics including rating and ranking metrics. As a side effect, the items being recommended tend to be popular items, which are the items mostly sold or viewed. It leaves the long-tail less popular items having less chance to get introduced to the users. This is the reason why ALS is not performing as well as a random recommender on diversity metrics. "
             ]
         },
         {

--- a/examples/05_operationalize/als_movie_o16n.ipynb
+++ b/examples/05_operationalize/als_movie_o16n.ipynb
@@ -633,7 +633,7 @@
             "source": [
                 "### 2.5 Evaluate how well ALS performs\n",
                 "\n",
-                "Evaluate model performance using metrics such as Precision@K, Recall@K, [MAP@K](https://en.wikipedia.org/wiki/Evaluation_measures_\\(information_retrieval\\) or [nDCG@K](https://en.wikipedia.org/wiki/Discounted_cumulative_gain). For a full guide on what metrics to evaluate your recommender with, consult [this guide]../03_evaluate/evaluation.ipynb)."
+                "Evaluate model performance using metrics such as Precision@K, Recall@K, [MAP@K](https://en.wikipedia.org/wiki/Evaluation_measures_\\(information_retrieval\\)) or [nDCG@K](https://en.wikipedia.org/wiki/Discounted_cumulative_gain). For a full guide on what metrics to evaluate your recommender with, consult [this guide](../03_evaluate/evaluation.ipynb)."
             ],
             "metadata": {}
         },
@@ -701,7 +701,7 @@
                 "print(\n",
                 "    \"Model:\\tALS\",\n",
                 "    \"Top K:\\t%d\" % rank_eval.k,\n",
-                "    \"MAP:\\t%f\" % rank_eval.map_at_k(),\n",
+                "    \"MAP@K:\\t%f\" % rank_eval.map_at_k(),\n",
                 "    \"NDCG:\\t%f\" % rank_eval.ndcg_at_k(),\n",
                 "    \"Precision@K:\\t%f\" % rank_eval.precision_at_k(),\n",
                 "    \"Recall@K:\\t%f\" % rank_eval.recall_at_k(), sep='\\n'\n",
@@ -714,7 +714,7 @@
                     "text": [
                         "Model:\tALS\n",
                         "Top K:\t10\n",
-                        "MAP:\t0.003698\n",
+                        "MAP@K:\t0.003698\n",
                         "NDCG:\t0.034331\n",
                         "Precision@K:\t0.039343\n",
                         "Recall@K:\t0.014976\n"


### PR DESCRIPTION
### Description

Follow-up for #2309 after #2316 moved the metric calculation to `map_at_k()`.

A few notebooks still displayed the resulting `map_at_k()` value as plain `MAP` or `Mean average precision`, which makes the output look like the non-`@k` metric even though the code is already computing MAP@k. This PR only updates those labels to `MAP@K` / `MAP@k` and fixes one broken markdown link in the same operationalization notebook paragraph.

### Related Issues

Fixes #2309.

### References

- #2316

### Checklist:

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.

Validation:

- Parsed the five changed notebooks as JSON.
- Ran `git diff --check`.
- Did not re-run the notebooks; the changes are stored output/source label updates only.
