### PR TITLE
test: fail fast when TensorFlow GPU is unavailable

### DIFF
--- a/tests/functional/examples/test_notebooks_gpu.py
+++ b/tests/functional/examples/test_notebooks_gpu.py
@@ -12,9 +12,25 @@ TOL = 0.1
 ABS_TOL = 0.05
 
 
+def _assert_tensorflow_gpu_available():
+    import tensorflow as tf
+
+    if not tf.config.list_physical_devices("GPU"):
+        pytest.fail(
+            "TensorFlow cannot see a GPU. Check CUDA/cuDNN availability before "
+            "running TensorFlow-backed GPU notebooks; otherwise they fall back to "
+            "CPU and can time out after an hour."
+        )
+
+
 @pytest.mark.gpu
 def test_gpu_vm():
     assert get_number_gpus() >= 1
+
+
+@pytest.mark.gpu
+def test_tensorflow_gpu_vm():
+    _assert_tensorflow_gpu_available()
 
 
 @pytest.mark.gpu
@@ -565,6 +581,8 @@ def test_lightgcn_deep_dive_functional(
 @pytest.mark.gpu
 @pytest.mark.notebooks
 def test_dkn_quickstart_functional(notebooks, output_notebook, kernel_name):
+    _assert_tensorflow_gpu_available()
+
     notebook_path = notebooks["dkn_quickstart"]
     execute_notebook(
         notebook_path,


### PR DESCRIPTION
### Description

Fixes #2312.

The linked gpu-nightly failure is not an NCF timeout. The failing test in that run is `test_dkn_quickstart_functional`, and TensorFlow logs show that the GPU libraries could not be loaded, so the notebook falls back to CPU and then burns an hour before timing out.

This PR adds a small TensorFlow GPU preflight:

- `test_tensorflow_gpu_vm` now fails quickly when TensorFlow cannot see a GPU.
- `test_dkn_quickstart_functional` checks the same condition before launching the notebook.

That keeps the failure focused on the runner/container CUDA/cuDNN setup instead of reporting it as a slow notebook failure after a long timeout.

### Related Issues

Fixes #2312

### References

The issue thread includes the linked gpu-nightly log analysis showing `test_dkn_quickstart_functional` timed out after TensorFlow skipped GPU registration.

### Checklist:

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.

Validation run locally:

- `python -m py_compile tests\functional\examples\test_notebooks_gpu.py`
- `python -m ruff check tests\functional\examples\test_notebooks_gpu.py`
- `git diff --check upstream/staging...HEAD`
- `Select-String -Path tests\functional\examples\test_notebooks_gpu.py -Pattern 'sk-[A-Za-z0-9_-]+'` returned no matches

I did not run the GPU notebook locally because this change specifically targets the GPU-nightly runner environment.
