### PR TITLE
Fix tfidf get_top_k_recommendations for NumPy 2.x (#2353)

### DIFF
--- a/recommenders/models/tfidf/tfidf_utils.py
+++ b/recommenders/models/tfidf/tfidf_utils.py
@@ -327,7 +327,7 @@ class TfidfRecommender:
         """
 
         # Return row
-        rec_info = metadata.iloc[int(np.where(metadata[self.id_col] == rec_id)[0])]
+        rec_info = metadata.iloc[int(np.where(metadata[self.id_col] == rec_id)[0][0])]
 
         return rec_info
 

--- a/tests/test_groups.yml
+++ b/tests/test_groups.yml
@@ -216,6 +216,7 @@ pr_gate:
     - tests/unit/recommenders/models/test_tfidf_utils.py::test_get_stop_words
     - tests/unit/recommenders/models/test_tfidf_utils.py::test_recommend_top_k_items
     - tests/unit/recommenders/models/test_tfidf_utils.py::test_get_top_k_recommendations                                                             #    0.03s
+    - tests/unit/recommenders/models/test_tfidf_utils.py::test_get_top_k_recommendations_scalar_index
     - tests/unit/recommenders/models/test_cornac_utils.py::test_predict                                                                              #    0.05s
     - tests/unit/recommenders/models/test_cornac_utils.py::test_recommend_k_items                                                                    #    0.13s
     - tests/unit/recommenders/models/test_sar_singlenode.py::test_init

--- a/tests/unit/recommenders/models/test_tfidf_utils.py
+++ b/tests/unit/recommenders/models/test_tfidf_utils.py
@@ -117,3 +117,29 @@ def test_get_top_k_recommendations(model_fit, df_clean):
     query_id = "ej795nks"
     displayed_top_k = model_fit.get_top_k_recommendations(df_clean, query_id=query_id)
     assert len(displayed_top_k.data) == K
+
+
+def test_get_top_k_recommendations_scalar_index():
+    # Regression test for #2353: get_top_k_recommendations must not raise on
+    # NumPy >= 2 ("only 0-dimensional arrays can be converted to Python
+    # scalars"). top_k_recommendations is set directly so the metadata lookup
+    # path is exercised without fitting a model.
+    recommender = TfidfRecommender(id_col="cord_uid", tokenization_method="none")
+    recommender.top_k_recommendations = pd.DataFrame(
+        {
+            "cord_uid": ["q", "q"],
+            "rec_cord_uid": ["9mzs5dl4", "u7lz3spe"],
+            "rec_rank": [1, 2],
+            "rec_score": [0.9, 0.8],
+        }
+    )
+    metadata = pd.DataFrame(
+        {
+            "cord_uid": ["q", "9mzs5dl4", "u7lz3spe"],
+            "title": ["Query", "Second", "Third"],
+        }
+    )
+    result = recommender.get_top_k_recommendations(
+        metadata, query_id="q", verbose=False
+    )
+    assert list(result["title"]) == ["Second", "Third"]


### PR DESCRIPTION
### Description

`TfidfRecommender.__get_single_item_info` passed `np.where(metadata[self.id_col] == rec_id)[0]` — a 1-D array — directly to `int()`. On NumPy >= 2 this raises:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

which breaks `get_top_k_recommendations` (e.g. when running the `tfidf_covid` example notebook). Indexing the first match (`[0][0]`) recovers the scalar row index, preserving the original single-match behavior while working on NumPy 2.x.

### Related Issues

Fixes #2353.

### References

- NumPy 1.25 deprecated, and NumPy 2.0 removed, converting an array with `ndim > 0` to a Python scalar.

### Checklist:

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly. <!-- N/A: bug fix, no doc change -->
- [x] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [x] This PR is being made to `staging branch` AND NOT TO `main branch`.
