### PR TITLE
Move numba to experimental extra and cap protobuf <5 for tensorflow compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     "notebook>=6.5.5,<8",  # requires ipykernel, jinja2, jupyter, nbconvert, nbformat, packaging, requests
     "numpy<2.0.0",  # See https://github.com/recommenders-team/recommenders/issues/2224
     "pandas>2.0.0,<3.0.0",  # requires numpy
-    "protobuf>=6.33.6,<8",
+    "protobuf>=3.20,<5",  # Capped at <5 for tensorflow<2.16 (gpu extra) compatibility; will change when #2073 is closed
     "pyarrow>=10.0.1",
     "retrying>=1.3.4,<2",
     "scikit-learn>=1.2.0,<2",  # requires scipy, and introduce breaking change affects feature_extraction.text.TfidfVectorizer.min_df

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ install_requires = [
     "memory-profiler>=0.61.0,<1",
     "nltk>=3.8.1,<4",  # requires tqdm
     "notebook>=6.5.5,<8",  # requires ipykernel, jinja2, jupyter, nbconvert, nbformat, packaging, requests
-    "numba>=0.57.0,<1",
     "numpy<2.0.0",  # See https://github.com/recommenders-team/recommenders/issues/2224
     "pandas>2.0.0,<3.0.0",  # requires numpy
     "protobuf>=6.33.6,<8",
@@ -77,6 +76,7 @@ extras_require["experimental"] = [
     "vowpalwabbit>=8.9.0,<9",
     # nni needs to be upgraded
     "nni==1.5",
+    "numba>=0.57.0,<1",  # only used by geoimc and rlrmc, which require pymanopt
     "pymanopt>=0.2.5",
     "lightfm>=1.17,<2",
     "scikit-surprise>=1.1.3",  # Put back in core deps when #2224 is fixed


### PR DESCRIPTION
## Description

Two dependency-only changes to `setup.py`:

### 1. Move `numba` from core to the `experimental` extra

After the GPU-info migration to `torch.cuda` (PRs #2345, #2349, tracked in #2344), `recommenders/utils/gpu_utils.py` no longer uses numba. The only remaining numba consumers are:

- `recommenders/models/geoimc/geoimc_algorithm.py`
- `recommenders/models/rlrmc/RLRMCalgorithm.py`

Both use `from numba import njit, prange` **and** import `pymanopt`, which already lives in `extras_require["experimental"]`. These models therefore cannot be imported without the experimental extra, so numba is effectively an experimental-only dependency and does not belong in core.

### 2. Cap `protobuf` at `<5` for `tensorflow<2.16` compatibility

`protobuf` was added to core in #2347 (needed by `transformers`/`BertTokenizer`, used by the CPU `tfidf_utils` model) and pinned `>=6.33.6,<8`. That floor is incompatible with the `gpu` extra's `tensorflow>=...,<2.16` (pinned per #2073), which requires `protobuf<5`. As a result the GPU Docker image fails to build during dependency resolution (`recommenders[gpu]` unsatisfiable), before any test runs — see e.g. the GPU jobs on #2337.

`transformers` works fine on protobuf 4.x, so lowering the cap keeps CPU behavior intact while unblocking the GPU install. The cap is tied to the `tensorflow<2.16` pin and will be relaxed when #2073 is closed.

## Change

- Remove `"numba>=0.57.0,<1"` from `install_requires`.
- Add it to `extras_require["experimental"]` (next to `pymanopt`) with a comment noting geoimc/rlrmc are its only consumers.
- Change `"protobuf>=6.33.6,<8"` → `"protobuf>=3.20,<5"` in `install_requires`, with a comment noting the cap exists for `tensorflow<2.16` (gpu extra) compatibility and will change when #2073 is closed.

Net effect: a lighter core install (numba only via `[experimental]`), and a resolvable `[gpu]` install (`protobuf==4.25.9`, compatible with `tensorflow==2.15.1`).

## Related Issues

- Follow-up to #2344
- Fixes the GPU dependency-resolution conflict from #2347 / #2073

## Checklist

- [x] I have not rewritten tests or code to pass CI without addressing the underlying issue.
- [x] I ran black to format the code.
- [x] I have added tests / this change requires no test (dependency-only change).
- [x] `setup.py` parses; numba appears only in the experimental extra; `[gpu]` and CPU-only both resolve to `protobuf==4.25.9`.
