### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/compshare-vm.yml
+++ b/.github/workflows/compshare-vm.yml
@@ -111,7 +111,6 @@ jobs:
       max-parallel: 6
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
         group: ${{ fromJSON(needs.get-test-groups.outputs.groups) }}

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/self-hosted-runner.yml
+++ b/.github/workflows/self-hosted-runner.yml
@@ -97,7 +97,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
         group: ${{ fromJSON(needs.get-test-groups.outputs.groups) }}

--- a/SETUP.md
+++ b/SETUP.md
@@ -61,7 +61,10 @@ uv pip install "recommenders[spark]"
 
 ## Setup for Databricks
 
-The following instructions were tested on Databricks Runtime 15.4 LTS (Apache Spark version 3.5.0), 14.3 LTS (Apache Spark version 3.5.0), 13.3 LTS (Apache Spark version 3.4.1), and 12.2 LTS (Apache Spark version 3.3.2). We have tested the runtime on python 3.9,3.10 and 3.11. 
+The following instructions were tested on Databricks Runtime 15.4 LTS
+(Apache Spark version 3.5.0), 14.3 LTS (Apache Spark version 3.5.0),
+13.3 LTS (Apache Spark version 3.4.1), and 12.2 LTS (Apache Spark
+version 3.3.2). We have tested the runtime on python 3.10 and 3.11.
 
 After an Databricks cluster is provisioned:
 ```bash

--- a/contrib/sarplus/python/setup.py
+++ b/contrib/sarplus/python/setup.py
@@ -39,7 +39,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Operating System :: POSIX :: Linux",

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -42,7 +42,7 @@ ARG COMPUTE
 # Extra dependencies: dev, gpu, spark
 ARG EXTRAS=""
 
-# Valid versions: 3.9, 3.10, 3.11
+# Valid versions: 3.10, 3.11
 ARG PYTHON_VERSION="3.11"
 
 ARG RECO_VENV_DIR=/root/.venvs/Recommenders


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR removes the support for Python 3.9.  As shown in [Status of Python versions](https://devguide.python.org/versions/), Python 3.9 has reached its end of life since 2025-10-31.  Most major packages has stopped the support for it, such as [numpy](https://pypi.org/project/numpy/) and [pandas](https://pypi.org/project/pandas/).

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->
* [Status of Python versions](https://devguide.python.org/versions/)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [X] I have updated the documentation accordingly.
- [X] I have [signed the commits](https://github.com/recommenders-team/recommenders/wiki/How-to-sign-commits), e.g. `git commit -s -m "your commit message"`.
- [X] This PR is being made to `staging branch` AND NOT TO `main branch`.
