### PR TITLE
Update BPR expected values after remove_seen fix

### DIFF
--- a/tests/functional/examples/test_notebooks_python.py
+++ b/tests/functional/examples/test_notebooks_python.py
@@ -283,8 +283,8 @@ def test_lightgbm_movielens_functional(notebooks, output_notebook, kernel_name):
 @pytest.mark.parametrize(
     "size, algos, expected_values_ndcg",
     [
-        (["100k"], ["sar", "bpr"], [0.393818, 0.444990]),
-        # (["100k"], ["svd", "sar", "bpr"], [0.094444, 0.393818, 0.444990]), # Put SVD surprise back in core deps when #2224 is fixed
+        (["100k"], ["sar", "bpr"], [0.393818, 0.362301]),
+        # (["100k"], ["svd", "sar", "bpr"], [0.094444, 0.393818, 0.362301]), # Put SVD surprise back in core deps when #2224 is fixed
     ],
 )
 def test_benchmark_movielens_cpu(

--- a/tests/functional/examples/test_notebooks_python.py
+++ b/tests/functional/examples/test_notebooks_python.py
@@ -179,7 +179,7 @@ def test_nni_tuning_svd(notebooks, output_notebook, kernel_name, tmp):
 @pytest.mark.parametrize(
     "size, expected_values",
     [
-        ("1m", dict(map=0.081390, ndcg=0.406627, precision=0.373228, recall=0.132444)),
+        ("1m", dict(map=0.186452, ndcg=0.314204, precision=0.271386, recall=0.161333)),
         # 10m works but takes too long
     ],
 )

--- a/tests/smoke/examples/test_notebooks_python.py
+++ b/tests/smoke/examples/test_notebooks_python.py
@@ -143,7 +143,7 @@ def test_cornac_bpr_smoke(notebooks, output_notebook, kernel_name):
     )
     results = read_notebook(output_notebook)
 
-    assert results["map"] == pytest.approx(0.1091, rel=TOL, abs=ABS_TOL)
-    assert results["ndcg"] == pytest.approx(0.4034, rel=TOL, abs=ABS_TOL)
-    assert results["precision"] == pytest.approx(0.3550, rel=TOL, abs=ABS_TOL)
-    assert results["recall"] == pytest.approx(0.1802, rel=TOL, abs=ABS_TOL)
+    assert results["map"] == pytest.approx(0.180368, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.305190, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.239032, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.208660, rel=TOL, abs=ABS_TOL)


### PR DESCRIPTION
### Description

The BPR model and its notebooks were fixed and re-executed, but the tests were not updated. So the tests still assert pre-fix numbers and fail.

Two deliberate changes moved these values: `recommenders/models/cornac/bpr.py` now applies `remove_seen` before top-k selection, and `examples/06_benchmarks/movielens.ipynb` binarizes and filters train and test at the rating threshold. The `map` figures also absorb the `map` to `map_at_k` change.

This PR only moves the test expectations to the values the notebooks already produce.

| Test | Notebook | Size | Metric | Old | New | Value in the notebook |
| --- | --- | --- | --- | --- | --- | --- |
| `test_benchmark_movielens_cpu` | [movielens.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/06_benchmarks/movielens.ipynb) | 100k | nDCG (bpr) | 0.444990 | 0.362301 | 0.362301 |
| `test_cornac_bpr_smoke` | [cornac_bpr_deep_dive.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb) | 100k | map | 0.1091 | 0.180368 | 0.180368 |
| `test_cornac_bpr_smoke` | [cornac_bpr_deep_dive.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb) | 100k | ndcg | 0.4034 | 0.305190 | 0.305190 |
| `test_cornac_bpr_smoke` | [cornac_bpr_deep_dive.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb) | 100k | precision | 0.3550 | 0.239032 | 0.239032 |
| `test_cornac_bpr_smoke` | [cornac_bpr_deep_dive.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb) | 100k | recall | 0.1802 | 0.208660 | 0.208660 |
| `test_cornac_bpr_functional` | [cornac_bpr_deep_dive.ipynb](https://github.com/recommenders-team/recommenders/blob/staging/examples/02_model_collaborative_filtering/cornac_bpr_deep_dive.ipynb) | 1m | map / ndcg / precision / recall | 0.081390 / 0.406627 / 0.373228 / 0.132444 | 0.186452 / 0.314204 / 0.271386 / 0.161333 | notebook is committed at 100k |

Each value comes from running the notebook with the parameters the test uses. The 1m row has no notebook value to cite because the notebook is committed at 100k.

The MAP-only test updates are in https://github.com/recommenders-team/recommenders/pull/2372, so each root cause stays reviewable on its own.

### Benefit

Unblocks `group_cpu_001` and `group_cpu_002` of the CPU nightly, which has had no green run since 2026-05-04. The tests now assert the model's corrected behaviour, so a future BPR regression will be visible instead of hiding behind an assertion that already fails.

### Risk

The 1m values were produced on a local CPU run rather than the CI VM. They are seed-stable here and the assertions carry `abs=0.05` tolerance, but the first nightly after merge is the real confirmation.

### Checklist:

- [x] I have followed the [contribution guidelines](https://github.com/recommenders-team/recommenders/blob/main/CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging` branch AND NOT TO `main` BRANCH.
